### PR TITLE
Add empty jsonb test skip flag

### DIFF
--- a/provider/providertest/resource.go
+++ b/provider/providertest/resource.go
@@ -24,10 +24,11 @@ import (
 )
 
 type ResourceTestData struct {
-	Table     *schema.Table
-	Config    interface{}
-	Resources []string
-	Configure func(logger hclog.Logger, data interface{}) (schema.ClientMeta, error)
+	Table          *schema.Table
+	Config         interface{}
+	Resources      []string
+	Configure      func(logger hclog.Logger, data interface{}) (schema.ClientMeta, error)
+	SkipEmptyJsonB bool
 }
 
 func TestResource(t *testing.T, providerCreator func() *provider.Provider, resource ResourceTestData) {
@@ -116,6 +117,9 @@ func verifyNoEmptyColumns(t *testing.T, tc ResourceTestData, conn pgxscan.Querie
 		}
 		if count < 1 {
 			t.Fatalf("expected to have at least 1 entry at table %s got %d", table, count)
+		}
+		if tc.SkipEmptyJsonB {
+			continue
 		}
 		query = fmt.Sprintf("select t.* FROM %s as t WHERE to_jsonb(t) = jsonb_strip_nulls(to_jsonb(t))", table)
 		rows, err = conn.Query(context.Background(), query)


### PR DESCRIPTION
This PR adds a small test flag (opt-in) that allows tests to skip the empty jsonb validation step.