### PR TITLE
insert on failed copy-from

### DIFF
--- a/provider/schema/database.go
+++ b/provider/schema/database.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"strings"
 
 	"github.com/modern-go/reflect2"
 
@@ -206,14 +205,6 @@ func quoteColumns(columns []string) []string {
 		columns[i] = strconv.Quote(v)
 	}
 	return columns
-}
-
-func buildReplaceColumns(columns []string) string {
-	replaceColumns := make([]string, len(columns))
-	for i, c := range columns {
-		replaceColumns[i] = fmt.Sprintf("%[1]s = EXCLUDED.%[1]s", c)
-	}
-	return strings.Join(replaceColumns, ",")
 }
 
 func TruncateTableConstraint(name string) string {

--- a/provider/schema/database_test.go
+++ b/provider/schema/database_test.go
@@ -129,11 +129,11 @@ func (_m *databaseMock) Exec(ctx context.Context, query string, args ...interfac
 }
 
 // Insert provides a mock function with given fields: ctx, t, instance
-func (_m *databaseMock) Insert(ctx context.Context, t *Table, instance []*Resource) error {
+func (_m *databaseMock) Insert(ctx context.Context, t *Table, instance Resources) error {
 	ret := _m.Called(ctx, t, instance)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *Table, []*Resource) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *Table, Resources) error); ok {
 		r0 = rf(ctx, t, instance)
 	} else {
 		r0 = ret.Error(0)


### PR DESCRIPTION
If copy-from fails try to normal "slower" insert, if conflicts arise on insert still fail. Future version can support single insert after conflict, on conflict print warning and continue.