### PR TITLE
Generate cq_id

### DIFF
--- a/provider/schema/execution.go
+++ b/provider/schema/execution.go
@@ -139,7 +139,7 @@ func (e ExecutionData) callTableResolve(ctx context.Context, client ClientMeta, 
 func (e ExecutionData) resolveResources(ctx context.Context, meta ClientMeta, parent *Resource, objects []interface{}) error {
 	var resources = make(Resources, len(objects))
 	for i, o := range objects {
-		resources[i] = NewResourceData(e.Table, parent, o, e.extraFields)
+		resources[i] = NewResourceData(e.Table, parent, o, e.extraFields, e.Logger)
 		// Before inserting resolve all table column resolvers
 		if err := e.resolveResourceValues(ctx, meta, resources[i]); err != nil {
 			e.Logger.Error("failed to resolve resource values", "error", err)

--- a/provider/schema/filters_test.go
+++ b/provider/schema/filters_test.go
@@ -20,7 +20,7 @@ func TestDeleteParentId(t *testing.T) {
 	mockedClient.On("Logger", mock.Anything).Return(logger)
 
 	object := testTableStruct{}
-	r := NewResourceData(testTable, nil, object, nil)
+	r := NewResourceData(testTable, nil, object, nil, nil)
 	_ = r.Set("name", "test")
 	assert.Equal(t, []interface{}{"name", r.Id()}, f(mockedClient, r))
 

--- a/provider/schema/resolvers_test.go
+++ b/provider/schema/resolvers_test.go
@@ -38,7 +38,7 @@ func TestPathResolver(t *testing.T) {
 	r1 := PathResolver("Inner.Value")
 	r2 := PathResolver("Value")
 	r3 := PathResolver("unexported")
-	resource := NewResourceData(pathTestTable, nil, testStruct{Inner: innerStruct{Value: "bla"}, Value: 5, unexported: false}, nil)
+	resource := NewResourceData(pathTestTable, nil, testStruct{Inner: innerStruct{Value: "bla"}, Value: 5, unexported: false}, nil, nil)
 	err := r1(context.TODO(), nil, resource, Column{Name: "test"})
 
 	assert.Nil(t, err)

--- a/provider/schema/resource.go
+++ b/provider/schema/resource.go
@@ -85,7 +85,7 @@ func (r *Resource) GenerateCQId() error {
 	for i, pk := range r.table.PrimaryKeys() {
 		value := r.Get(pk)
 		if value == nil {
-			//return error because main table should have primary keys set
+			// main table should have primary keys set, relations can have randomly generated cq_id
 			if r.Parent == nil {
 				return fmt.Errorf("failed to generate cq_id for %s, pk field missing %s", r.table.Name, pk)
 			} else {


### PR DESCRIPTION
generates random cq_id  for child resources if there are `nil` primary keys 
fixes #63 