### PR TITLE
update sdk logging for syntax insert error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,8 @@ require (
 	github.com/hashicorp/yamux v0.0.0-20210316155119-a95892c5f864 // indirect
 	github.com/huandu/go-sqlbuilder v1.12.1
 	github.com/iancoleman/strcase v0.1.3
+	github.com/jackc/pgconn v1.8.1
+	github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451
 	github.com/jackc/pgmock v0.0.0-20201204152224-4fe30f7445fd // indirect
 	github.com/jackc/pgproto3/v2 v2.0.7 // indirect
 	github.com/jackc/pgx/v4 v4.11.0

--- a/go.sum
+++ b/go.sum
@@ -389,6 +389,8 @@ github.com/jackc/pgconn v1.7.0/go.mod h1:sF/lPpNEMEOp+IYhyQGdAvrG20gWf6A1tKlr0v7
 github.com/jackc/pgconn v1.8.0/go.mod h1:1C2Pb36bGIP9QHGBYCjnyhqu7Rv3sGshaQUvmfGIB/o=
 github.com/jackc/pgconn v1.8.1 h1:ySBX7Q87vOMqKU2bbmKbUvtYhauDFclYbNDYIE1/h6s=
 github.com/jackc/pgconn v1.8.1/go.mod h1:JV6m6b6jhjdmzchES0drzCcYcAHS1OPD5xu3OZ/lE2g=
+github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451 h1:WAvSpGf7MsFuzAtK4Vk7R4EVe+liW4x83r4oWu0WHKw=
+github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgio v1.0.0 h1:g12B9UwVnzGhueNavwioyEEpAmqMe1E/BN9ES+8ovkE=
 github.com/jackc/pgio v1.0.0/go.mod h1:oP+2QK2wFfUWgr+gxjoBH9KGBb31Eio69xUb0w5bYf8=
 github.com/jackc/pgmock v0.0.0-20190831213851-13a1b77aafa2/go.mod h1:fGZlG77KXmcq05nJLRkk0+p82V8B8Dw8KN2/V9c/OAE=

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -132,7 +132,7 @@ func (p *Provider) FetchResources(ctx context.Context, request *cqproto.FetchRes
 		return err
 	}
 
-	conn, err := schema.NewPgDatabase(ctx, p.dbURL)
+	conn, err := schema.NewPgDatabase(ctx, p.Logger, p.dbURL)
 	if err != nil {
 		return fmt.Errorf("failed to connect to database. %w", err)
 	}

--- a/provider/schema/database.go
+++ b/provider/schema/database.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/go-hclog"
-	"github.com/jackc/pgconn"
 	"reflect"
 	"strconv"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/jackc/pgconn"
 
 	"github.com/modern-go/reflect2"
 
@@ -38,7 +39,7 @@ type Database interface {
 
 type PgDatabase struct {
 	pool *pgxpool.Pool
-	log hclog.Logger
+	log  hclog.Logger
 }
 
 func NewPgDatabase(ctx context.Context, logger hclog.Logger, dsn string) (*PgDatabase, error) {

--- a/provider/schema/execution.go
+++ b/provider/schema/execution.go
@@ -243,7 +243,7 @@ func (e *ExecutionData) copyDataIntoDB(ctx context.Context, resources Resources,
 	partialFetchResources := make(Resources, 0)
 	for id := range resources {
 		if err := e.Db.Insert(ctx, e.Table, Resources{resources[id]}); err != nil {
-			e.Logger.Error("failed to insert resource into db", "error", err, "resource", resources[id], "table", e.Table.Name)
+			e.Logger.Error("failed to insert resource into db", "error", err, "resource_keys", resources[id].String(), "table", e.Table.Name)
 		} else {
 			// If there is no error we add the resource to the final result
 			partialFetchResources = append(partialFetchResources, resources[id])

--- a/provider/schema/resource.go
+++ b/provider/schema/resource.go
@@ -41,7 +41,7 @@ func NewResourceData(t *Table, parent *Resource, item interface{}, extraFields m
 func (r *Resource) String() string {
 	keys := make([]interface{}, len(r.table.PrimaryKeys()))
 	for _, pk := range r.table.PrimaryKeys() {
-		keys  = append(keys, r.Get(pk))
+		keys = append(keys, r.Get(pk))
 	}
 	return fmt.Sprintf("%s", keys)
 }

--- a/provider/schema/resource.go
+++ b/provider/schema/resource.go
@@ -38,6 +38,13 @@ func NewResourceData(t *Table, parent *Resource, item interface{}, extraFields m
 		extraFields: extraFields,
 	}
 }
+func (r *Resource) String() string {
+	keys := make([]interface{}, len(r.table.PrimaryKeys()))
+	for _, pk := range r.table.PrimaryKeys() {
+		keys  = append(keys, r.Get(pk))
+	}
+	return fmt.Sprintf("%s", keys)
+}
 
 func (r *Resource) Get(key string) interface{} {
 	return r.data[key]


### PR DESCRIPTION
- Print SQL in case of syntax error
- Only print resource primary keys in case of insert failure instead of full resource.