### PR TITLE
Add column name to resolver errors

### DIFF
--- a/provider/schema/execution.go
+++ b/provider/schema/execution.go
@@ -341,7 +341,7 @@ func (e *ExecutionData) resolveColumns(ctx context.Context, meta ClientMeta, res
 			}
 			// check if column resolver defined an IgnoreError function, if it does check if ignore should be ignored.
 			if c.IgnoreError == nil || !c.IgnoreError(err) {
-				return err
+				return fmt.Errorf("column %s: %w", c.Name, err)
 			}
 
 			if reflect2.IsNil(c.Default) {


### PR DESCRIPTION
Fixes #114

It's not easy to get the value in general but the column name is possible.