### PR TITLE
Fix parallel tests for identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### :gear: Changed
+* Fix table and column name limit tests [#134](https://github.com/cloudquery/cq-provider-sdk/pull/134).
 
 ## [v0.5.6] - 2021-12-18
 

--- a/provider/testing/resource.go
+++ b/provider/testing/resource.go
@@ -173,22 +173,25 @@ func getTablesFromMainTable(table *schema.Table) []string {
 }
 
 func testTableIdentifiersForProvider(t *testing.T, prov *provider.Provider) {
-	t.Parallel()
-	for _, res := range prov.ResourceMap {
-		res := res
-		t.Run(res.Name, func(t *testing.T) {
-			testTableIdentifiers(t, res)
-		})
-	}
+	t.Run("testTableIdentifiersForProvider", func(t *testing.T) {
+		t.Parallel()
+		for _, res := range prov.ResourceMap {
+			res := res
+			t.Run(res.Name, func(t *testing.T) {
+				testTableIdentifiers(t, res)
+			})
+		}
+	})
 }
 
 func testTableIdentifiers(t *testing.T, table *schema.Table) {
+	t.Parallel()
 	assert.NoError(t, schema.ValidateTable(table))
 
 	for _, res := range table.Relations {
 		res := res
 		t.Run(res.Name, func(t *testing.T) {
-			assert.NoError(t, schema.ValidateTable(res))
+			testTableIdentifiers(t, res)
 		})
 	}
 }


### PR DESCRIPTION
Passing the `*testing.T` to a fn to do further tests (which called `t.Parallel()`) was making the tests run parallel from then on, which is bad. Also sub-sub-relations weren't getting tested.