### PR TITLE
make read migration files visible outside package

### DIFF
--- a/provider/migrations.go
+++ b/provider/migrations.go
@@ -30,7 +30,7 @@ const (
 	dropTableSQL                    = "DROP TABLE IF EXISTS %s CASCADE"
 )
 
-func readProviderMigrationFiles(log hclog.Logger, migrationFiles embed.FS) (map[string][]byte, error) {
+func ReadMigrationFiles(log hclog.Logger, migrationFiles embed.FS) (map[string][]byte, error) {
 	var (
 		err        error
 		migrations = make(map[string][]byte)

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -63,7 +63,7 @@ type Provider struct {
 }
 
 func (p *Provider) GetProviderSchema(_ context.Context, _ *cqproto.GetProviderSchemaRequest) (*cqproto.GetProviderSchemaResponse, error) {
-	m, err := readProviderMigrationFiles(p.Logger, p.Migrations)
+	m, err := ReadMigrationFiles(p.Logger, p.Migrations)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I made a function visible to be used by cloudquery core for migrations