### PR TITLE
fix: Redact DSN parse errors

### DIFF
--- a/database/postgres/connection.go
+++ b/database/postgres/connection.go
@@ -3,16 +3,17 @@ package postgres
 import (
 	"context"
 
+	"github.com/cloudquery/cq-provider-sdk/database/dsn"
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 )
 
 // Connect connects to the given DSN and returns a pgxpool
-func Connect(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
-	poolCfg, err := pgxpool.ParseConfig(dsn)
+func Connect(ctx context.Context, dsnURI string) (*pgxpool.Pool, error) {
+	poolCfg, err := pgxpool.ParseConfig(dsnURI)
 	if err != nil {
-		return nil, err
+		return nil, dsn.RedactParseError(err)
 	}
 	poolCfg.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
 		UUIDType := pgtype.DataType{


### PR DESCRIPTION
pgconn does a good job of redacting the password, but it wraps the net/url's parse error, which includes the original URI
dburl returns url.Parse errors as-is