### PR TITLE
fix: Migrator should consider dialect columns

### DIFF
--- a/migration/table.go
+++ b/migration/table.go
@@ -150,6 +150,9 @@ func (m TableCreator) DiffTable(ctx context.Context, conn *pgxpool.Conn, schemaN
 			m.log.Warn("column missing from table, not adding it", "table", t.Name, "column", d)
 			continue
 		}
+		if col.Internal() {
+			continue
+		}
 
 		var notice string
 		if v, ok := similars[d]; ok {
@@ -168,7 +171,9 @@ func (m TableCreator) DiffTable(ctx context.Context, conn *pgxpool.Conn, schemaN
 	for _, d := range columnsToRemove {
 		m.log.Debug("removing column", "column", d)
 		if col := t.Column(d); col != nil {
-			m.log.Warn("column still in table, not removing it", "table", t.Name, "column", d)
+			if !col.Internal() {
+				m.log.Warn("column still in table, not removing it", "table", t.Name, "column", d)
+			}
 			continue
 		}
 

--- a/migration/table.go
+++ b/migration/table.go
@@ -134,7 +134,9 @@ func (m TableCreator) DiffTable(ctx context.Context, conn *pgxpool.Conn, schemaN
 		dbColTypes[existingColumns.Columns[i]] = strings.ToLower(existingColumns.Types[i])
 	}
 
-	columnsToAdd, columnsToRemove := funk.DifferenceString(m.dialect.Columns(t).Names(), existingColumns.Columns)
+	tableColsWithDialect := m.dialect.Columns(t)
+
+	columnsToAdd, columnsToRemove := funk.DifferenceString(tableColsWithDialect.Names(), existingColumns.Columns)
 	similars := getSimilars(m.dialect, t, columnsToAdd, columnsToRemove, dbColTypes)
 
 	capSize := len(columnsToAdd) + len(columnsToRemove) // relations not included...
@@ -143,7 +145,7 @@ func (m TableCreator) DiffTable(ctx context.Context, conn *pgxpool.Conn, schemaN
 
 	for _, d := range columnsToAdd {
 		m.log.Debug("adding column", "column", d)
-		col := t.Column(d)
+		col := tableColsWithDialect.Get(d)
 		if col == nil {
 			m.log.Warn("column missing from table, not adding it", "table", t.Name, "column", d)
 			continue

--- a/provider/schema/column.go
+++ b/provider/schema/column.go
@@ -171,6 +171,10 @@ type Column struct {
 	meta *ColumnMeta
 }
 
+func (c Column) Internal() bool {
+	return c.internal
+}
+
 func (c Column) ValidateType(v interface{}) error {
 	if !c.checkType(v) {
 		return fmt.Errorf("column %s expected %s got %T", c.Name, c.Type.String(), v)

--- a/provider/schema/column.go
+++ b/provider/schema/column.go
@@ -333,3 +333,12 @@ func (c ColumnList) Names() []string {
 	}
 	return ret
 }
+
+func (c ColumnList) Get(name string) *Column {
+	for i := range c {
+		if c[i].Name == name {
+			return &c[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This will stop the warning messages when running properly
It will start adding cq_fetch_date if running on an improperly initialised (not TSDB, but in `tsdb://` mode) DB though
