### PR TITLE
fix: Sub-resource partial fetch error handling

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -179,7 +179,7 @@ func (p *Provider) FetchResources(ctx context.Context, request *cqproto.FetchRes
 
 	g, gctx := errgroup.WithContext(ctx)
 	finishedResources := make(map[string]bool, len(resources))
-	l := sync.Mutex{}
+	l := &sync.Mutex{}
 	var totalResourceCount uint64 = 0
 	for _, resource := range resources {
 		table, ok := p.ResourceMap[resource]
@@ -202,9 +202,9 @@ func (p *Provider) FetchResources(ctx context.Context, request *cqproto.FetchRes
 			}
 			resourceCount, err := execData.ResolveTable(gctx, p.meta, nil)
 			l.Lock()
+			defer l.Unlock()
 			finishedResources[r] = true
 			atomic.AddUint64(&totalResourceCount, resourceCount)
-			defer l.Unlock()
 			if err != nil {
 				status := cqproto.ResourceFetchFailed
 				if err == context.Canceled {


### PR DESCRIPTION
```
✓ cq-provider-aws@latest fetch complete    2s   Finished Resources: 1/1

Fetch Diagnostics for provider aws:

Resource: sagemaker.training_jobs Type: Resolving Severity: Error
        Summary: failed to resolve resource: recovered from panic: runtime error: invalid memory address or nil pointer dereference

Provider fetch complete.

Provider aws fetch summary: ✓ Total Resources fetched: 1         ⚠️ Warnings: 0  ❌ Errors: 1
```
