### PR TITLE
fix: More DSN redactions

### DIFF
--- a/database/dsn/dsn.go
+++ b/database/dsn/dsn.go
@@ -3,6 +3,7 @@ package dsn
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 
@@ -64,6 +65,12 @@ func RedactParseError(err error) error {
 	if errors.As(err, &e) {
 		e.URL = "DSN redacted"
 		return e
+	}
+
+	var ne *net.AddrError
+	if errors.As(err, &ne) {
+		ne.Addr = "DSN redacted"
+		return fmt.Errorf("parse: %w", ne)
 	}
 
 	return err

--- a/database/dsn/dsn_test.go
+++ b/database/dsn/dsn_test.go
@@ -89,20 +89,26 @@ func TestRedactDSNErrors(t *testing.T) {
 	for _, brokenDSN := range []string{
 		"postgres://postgres:pass%@localhost:5432/postgres?sslmode=disable",
 		"postgres://postgres:pass@localhost:A/postgres?sslmode=disable",
+		`postgres://user:pass://user:pass/postgres?sslmode=disable`,
 	} {
 		{
 			result, err := ParseConnectionString(brokenDSN)
-			assert.Nil(t, result)
-			assert.Error(t, err)
-			assert.True(t, strings.Contains(err.Error(), "DSN redacted"))
+			if err != nil {
+				assert.Nil(t, result)
+				assert.Error(t, err)
+				assert.True(t, strings.Contains(err.Error(), "DSN redacted"))
+			}
 		}
 
 		{
 			result, err := pgconn.ParseConfig(brokenDSN)
 			assert.Nil(t, result)
 			assert.Error(t, err)
-			err = RedactParseError(err)
-			assert.True(t, strings.Contains(err.Error(), "DSN redacted"))
+			if err != nil {
+				err = RedactParseError(err)
+				assert.Error(t, err)
+				assert.True(t, strings.Contains(err.Error(), "DSN redacted"))
+			}
 		}
 	}
 }


### PR DESCRIPTION
If the DSN manages to pass through a net.Addr parser and fails there, `net.AddrError` leaks connection details in the error message.