### PR TITLE
fix: Better counting of squashed diagnostics

### DIFF
--- a/provider/diag/diagnostics.go
+++ b/provider/diag/diagnostics.go
@@ -91,7 +91,7 @@ func (diags Diagnostics) Add(new ...interface{}) Diagnostics {
 func (diags Diagnostics) Squash() Diagnostics {
 	dd := make(map[string]*SquashedDiag, len(diags))
 	sdd := make(Diagnostics, 0)
-	for _, d := range diags {
+	for i, d := range diags {
 		keygen := d
 		if rd, ok := d.(Redactable); ok {
 			if r := rd.Redacted(); r != nil {
@@ -105,7 +105,7 @@ func (diags Diagnostics) Squash() Diagnostics {
 			continue
 		}
 		nsd := &SquashedDiag{
-			Diagnostic: d,
+			Diagnostic: diags[i],
 			count:      CountDiag(d),
 		}
 		dd[key] = nsd

--- a/provider/diag/diagnostics.go
+++ b/provider/diag/diagnostics.go
@@ -92,7 +92,14 @@ func (diags Diagnostics) Squash() Diagnostics {
 	dd := make(map[string]*SquashedDiag, len(diags))
 	sdd := make(Diagnostics, 0)
 	for _, d := range diags {
-		key := fmt.Sprintf("%s_%s_%d_%d", d.Error(), d.Description().Resource, d.Severity(), d.Type())
+		keygen := d
+		if rd, ok := d.(Redactable); ok {
+			if r := rd.Redacted(); r != nil {
+				keygen = r
+			}
+		}
+
+		key := fmt.Sprintf("%s_%s_%d_%d", keygen.Error(), keygen.Description().Resource, keygen.Severity(), keygen.Type())
 		if sd, ok := dd[key]; ok {
 			sd.count += CountDiag(d)
 			continue

--- a/provider/diag/diagnostics.go
+++ b/provider/diag/diagnostics.go
@@ -94,12 +94,12 @@ func (diags Diagnostics) Squash() Diagnostics {
 	for _, d := range diags {
 		key := fmt.Sprintf("%s_%s_%d_%d", d.Error(), d.Description().Resource, d.Severity(), d.Type())
 		if sd, ok := dd[key]; ok {
-			sd.Count++
+			sd.count += CountDiag(d)
 			continue
 		}
 		nsd := &SquashedDiag{
 			Diagnostic: d,
-			Count:      1,
+			count:      CountDiag(d),
 		}
 		dd[key] = nsd
 		sdd = append(sdd, nsd)
@@ -108,23 +108,22 @@ func (diags Diagnostics) Squash() Diagnostics {
 }
 
 func (diags Diagnostics) Warnings() uint64 {
-	var warningsCount uint64 = 0
-	for _, d := range diags {
-		if d.Severity() == WARNING {
-			warningsCount++
-		}
-	}
-	return warningsCount
+	return diags.CountBySeverity(WARNING)
 }
 
 func (diags Diagnostics) Errors() uint64 {
-	var errorCount uint64 = 0
+	return diags.CountBySeverity(ERROR)
+}
+
+func (diags Diagnostics) CountBySeverity(sev Severity) uint64 {
+	var count uint64 = 0
+
 	for _, d := range diags {
-		if d.Severity() == ERROR {
-			errorCount++
+		if d.Severity() == sev {
+			count += CountDiag(d)
 		}
 	}
-	return errorCount
+	return count
 }
 
 func (diags Diagnostics) Len() int      { return len(diags) }

--- a/provider/diag/diagnostics_test.go
+++ b/provider/diag/diagnostics_test.go
@@ -29,7 +29,7 @@ func TestDiagnostics_Squash(t *testing.T) {
 					Description: Description{
 						Resource: "a",
 						Summary:  "some summary",
-						Detail:   "Repeated[2]",
+						Detail:   "[Repeated:2]",
 					},
 				},
 			},
@@ -39,6 +39,8 @@ func TestDiagnostics_Squash(t *testing.T) {
 			Value: Diagnostics{
 				NewBaseError(errors.New("error test"), ERROR, RESOLVING, "a", "some summary", "some details"),
 				NewBaseError(errors.New("error test"), ERROR, RESOLVING, "a", "some summary", "some details"),
+				NewBaseError(errors.New("error test2"), ERROR, RESOLVING, "a", "some summary2", "some details2."),
+				NewBaseError(errors.New("error test2"), ERROR, RESOLVING, "a", "some summary2", "some details2."),
 			},
 			Want: []FlatDiag{
 				{
@@ -50,7 +52,19 @@ func TestDiagnostics_Squash(t *testing.T) {
 					Description: Description{
 						Resource: "a",
 						Summary:  "some summary",
-						Detail:   "Repeated[2]: some details",
+						Detail:   "some details. [Repeated:2]",
+					},
+				},
+				{
+					Err:      "error test2",
+					Resource: "a",
+					Type:     RESOLVING,
+					Severity: ERROR,
+					Summary:  "some summary2",
+					Description: Description{
+						Resource: "a",
+						Summary:  "some summary2",
+						Detail:   "some details2. [Repeated:2]",
 					},
 				},
 			},

--- a/provider/diag/squash.go
+++ b/provider/diag/squash.go
@@ -11,6 +11,10 @@ type SquashedDiag struct {
 }
 
 func (s SquashedDiag) Description() Description {
+	if _, ok := s.Diagnostic.(Countable); ok { // already squashed, don't add repeat count
+		return s.Diagnostic.Description()
+	}
+
 	description := s.Diagnostic.Description()
 
 	switch {
@@ -29,6 +33,23 @@ func (s SquashedDiag) Description() Description {
 
 func (s SquashedDiag) Count() uint64 {
 	return s.count
+}
+
+func (s SquashedDiag) Redacted() Diagnostic {
+	rd, ok := s.Diagnostic.(Redactable)
+	if !ok {
+		return nil
+	}
+
+	r := rd.Redacted()
+	if r == nil {
+		return nil
+	}
+
+	return SquashedDiag{
+		Diagnostic: r,
+		count:      s.count,
+	}
 }
 
 type Countable interface {

--- a/provider/diag/squash.go
+++ b/provider/diag/squash.go
@@ -1,6 +1,9 @@
 package diag
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type SquashedDiag struct {
 	Diagnostic
@@ -9,13 +12,16 @@ type SquashedDiag struct {
 
 func (s SquashedDiag) Description() Description {
 	description := s.Diagnostic.Description()
-	if s.count == 1 {
-		return description
-	}
-	if description.Detail == "" {
+
+	switch {
+	case s.count == 1:
+		// no-op
+	case description.Detail == "":
 		description.Detail = fmt.Sprintf("Repeated[%d]", s.count)
-	} else {
-		description.Detail = fmt.Sprintf("Repeated[%d]: %s", s.count, description.Detail)
+	case strings.HasSuffix(description.Detail, "."):
+		description.Detail = fmt.Sprintf("%s [Repeated:%d]", description.Detail, s.count)
+	default:
+		description.Detail = fmt.Sprintf("%s. [Repeated:%d]", description.Detail, s.count)
 	}
 
 	return description

--- a/provider/diag/squash.go
+++ b/provider/diag/squash.go
@@ -17,7 +17,7 @@ func (s SquashedDiag) Description() Description {
 	case s.count == 1:
 		// no-op
 	case description.Detail == "":
-		description.Detail = fmt.Sprintf("Repeated[%d]", s.count)
+		description.Detail = fmt.Sprintf("[Repeated:%d]", s.count)
 	case strings.HasSuffix(description.Detail, "."):
 		description.Detail = fmt.Sprintf("%s [Repeated:%d]", description.Detail, s.count)
 	default:

--- a/provider/diag/squash.go
+++ b/provider/diag/squash.go
@@ -4,19 +4,37 @@ import "fmt"
 
 type SquashedDiag struct {
 	Diagnostic
-	Count int
+	count uint64
 }
 
 func (s SquashedDiag) Description() Description {
 	description := s.Diagnostic.Description()
-	if s.Count == 1 {
+	if s.count == 1 {
 		return description
 	}
 	if description.Detail == "" {
-		description.Detail = fmt.Sprintf("Repeated[%d]", s.Count)
+		description.Detail = fmt.Sprintf("Repeated[%d]", s.count)
 	} else {
-		description.Detail = fmt.Sprintf("Repeated[%d]: %s", s.Count, description.Detail)
+		description.Detail = fmt.Sprintf("Repeated[%d]: %s", s.count, description.Detail)
 	}
 
 	return description
 }
+
+func (s SquashedDiag) Count() uint64 {
+	return s.count
+}
+
+type Countable interface {
+	Count() uint64
+}
+
+func CountDiag(d Diagnostic) uint64 {
+	if c, ok := d.(Countable); ok {
+		return c.Count()
+	}
+
+	return 1
+}
+
+var _ Countable = (*SquashedDiag)(nil)

--- a/provider/diag/squash.go
+++ b/provider/diag/squash.go
@@ -11,11 +11,11 @@ type SquashedDiag struct {
 }
 
 func (s SquashedDiag) Description() Description {
-	if _, ok := s.Diagnostic.(Countable); ok { // already squashed, don't add repeat count
-		return s.Diagnostic.Description()
-	}
-
 	description := s.Diagnostic.Description()
+
+	if _, ok := s.Diagnostic.(Countable); ok { // already squashed, don't add repeat count
+		return description
+	}
 
 	switch {
 	case s.count == 1:


### PR DESCRIPTION
This way you could squash a diag multiple times, also warning/error counts are corrected