### PR TITLE
fix: Clean up tablecreator, remove enable_partial_fetch in config template

### DIFF
--- a/migration/table.go
+++ b/migration/table.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/cloudquery/cq-provider-sdk/migration/longestcommon"
-	"github.com/cloudquery/cq-provider-sdk/provider/execution"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 
 	"github.com/georgysavva/scany/pgxscan"
@@ -36,20 +35,6 @@ func NewTableCreator(log hclog.Logger, dialect schema.Dialect) *TableCreator {
 		log:     log,
 		dialect: dialect,
 	}
-}
-
-// CreateTable generates CREATE TABLE definitions for the given table and runs them on the given conn
-func (m TableCreator) CreateTable(ctx context.Context, conn execution.QueryExecer, t, p *schema.Table) error {
-	ups, _, err := m.CreateTableDefinitions(ctx, t, p)
-	if err != nil {
-		return err
-	}
-	for _, sql := range ups {
-		if err := conn.Exec(ctx, sql); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // CreateTableDefinitions reads schema.Table and builds the CREATE TABLE and DROP TABLE statements for it, also processing and returning subrelation tables

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -89,8 +89,6 @@ func (p *Provider) GetProviderConfig(_ context.Context, _ *cqproto.GetProviderCo
 			%s
 			// list of resources to fetch
 			resources = %s
-			// enables partial fetching, allowing for any failures to not stop full resource pull
-			enable_partial_fetch = true
 		}`, p.Name, p.Config().Example(), helpers.FormatSlice(funk.Keys(p.ResourceMap).([]string)))
 
 	return &cqproto.GetProviderConfigResponse{Config: hclwrite.Format([]byte(data))}, nil

--- a/provider/testing/resource.go
+++ b/provider/testing/resource.go
@@ -37,7 +37,6 @@ func init() {
 	_ = faker.SetRandomMapAndSliceMaxSize(1)
 }
 
-// IntegrationTest - creates resources using terraform, fetches them to db and compares with expected values
 func TestResource(t *testing.T, resource ResourceTestCase) {
 	if !resource.NotParallel {
 		t.Parallel()


### PR DESCRIPTION
TableCreator: No more CreateTable(), fix it in the one place it is used
Config Template: Remove `enable_partial_fetch = true` as it's always assumed true after https://github.com/cloudquery/cloudquery/pull/495