### PR TITLE
feat: Add migrator prehook

### DIFF
--- a/migration/migrator/migrator_test.go
+++ b/migration/migrator/migrator_test.go
@@ -61,7 +61,7 @@ func getDBUrl() string {
 }
 
 func TestMigrations(t *testing.T) {
-	m, err := New(hclog.Default(), schema.Postgres, simpleMigrations, getDBUrl(), "test", nil)
+	m, err := New(hclog.Default(), schema.Postgres, simpleMigrations, getDBUrl(), "test")
 	assert.Nil(t, err)
 
 	err = m.DropProvider(context.Background(), nil)
@@ -97,7 +97,7 @@ func TestMigrations(t *testing.T) {
 
 // TestMigrationJumps tests an edge case we request a higher version but latest migration is a previous version
 func TestMigrationJumps(t *testing.T) {
-	m, err := New(hclog.Default(), schema.Postgres, complexMigrations, getDBUrl(), "test", nil)
+	m, err := New(hclog.Default(), schema.Postgres, complexMigrations, getDBUrl(), "test")
 	assert.Nil(t, err)
 
 	err = m.DropProvider(context.Background(), nil)
@@ -111,10 +111,10 @@ func TestMigrationJumps(t *testing.T) {
 }
 
 func TestMultiProviderMigrations(t *testing.T) {
-	mtest, err := New(hclog.Default(), schema.Postgres, simpleMigrations, getDBUrl(), "test", nil)
+	mtest, err := New(hclog.Default(), schema.Postgres, simpleMigrations, getDBUrl(), "test")
 	assert.Nil(t, err)
 
-	mtest2, err := New(hclog.Default(), schema.Postgres, simpleMigrations, getDBUrl(), "test2", nil)
+	mtest2, err := New(hclog.Default(), schema.Postgres, simpleMigrations, getDBUrl(), "test2")
 	assert.Nil(t, err)
 
 	err = mtest.DropProvider(context.Background(), nil)
@@ -146,7 +146,7 @@ func TestMultiProviderMigrations(t *testing.T) {
 }
 
 func TestFindLatestMigration(t *testing.T) {
-	mtest, err := New(hclog.Default(), schema.Postgres, complexMigrations, getDBUrl(), "test", nil)
+	mtest, err := New(hclog.Default(), schema.Postgres, complexMigrations, getDBUrl(), "test")
 	assert.Nil(t, err)
 	mv, err := mtest.FindLatestMigration("v0.0.3")
 	assert.Nil(t, err)
@@ -255,7 +255,7 @@ func TestNoSchemaError(t *testing.T) {
 		}
 	}
 
-	m, err := New(hclog.Default(), schema.Postgres, simpleMigrations, weakDSN, "test", nil)
+	m, err := New(hclog.Default(), schema.Postgres, simpleMigrations, weakDSN, "test")
 	assert.Nil(t, m)
 	if t.Failed() {
 		m.Close()

--- a/migration/testbuilder.go
+++ b/migration/testbuilder.go
@@ -117,7 +117,7 @@ func doMigrationsTest(t *testing.T, ctx context.Context, dsn string, prov *provi
 	migFiles, err := migrator.ReadMigrationFiles(hclog.L(), prov.Migrations)
 	assert.NoError(t, err)
 
-	mig, err := migrator.New(hclog.L(), dialect, migFiles, dsn, prov.Name, nil)
+	mig, err := migrator.New(hclog.L(), dialect, migFiles, dsn, prov.Name)
 	assert.NoError(t, err)
 	if t.Failed() {
 		t.FailNow()


### PR DESCRIPTION
This was needed to be able to 'drop views' on timescaledb dialect executor before the migrator was run.