### PR TITLE
feat: Ignore Table Completely in test

### DIFF
--- a/provider/testing/resource.go
+++ b/provider/testing/resource.go
@@ -77,7 +77,10 @@ func TestResource(t *testing.T, resource ResourceTestCase) {
 func fetch(t *testing.T, resource *ResourceTestCase) error {
 	t.Helper()
 	resourceNames := make([]string, 0, len(resource.Provider.ResourceMap))
-	for name := range resource.Provider.ResourceMap {
+	for name, table := range resource.Provider.ResourceMap {
+		if table.IgnoreInTests {
+			continue
+		}
 		resourceNames = append(resourceNames, name)
 	}
 

--- a/provider/testing/resource.go
+++ b/provider/testing/resource.go
@@ -79,6 +79,7 @@ func fetch(t *testing.T, resource *ResourceTestCase) error {
 	resourceNames := make([]string, 0, len(resource.Provider.ResourceMap))
 	for name, table := range resource.Provider.ResourceMap {
 		if table.IgnoreInTests {
+			t.Logf("skipping resource: %s in tests", name)
 			continue
 		}
 		resourceNames = append(resourceNames, name)


### PR DESCRIPTION
When an entire table is ignored, then we should just skip fetching: https://github.com/cloudquery/cq-provider-gcp/pull/190

This only works for parent tables though