### PR TITLE
fix: Backwards compatibility with old CQ Core

### DIFF
--- a/cqproto/grpc.go
+++ b/cqproto/grpc.go
@@ -172,10 +172,13 @@ func (g *GRPCServer) ConfigureProvider(ctx context.Context, request *internal.Co
 	if err != nil {
 		return nil, err
 	}
+	if resp.Diagnostics.HasErrors() { // For backwards compatibility
+		err = resp.Diagnostics
+	}
 	return &internal.ConfigureProvider_Response{
-		Error:       resp.Diagnostics.Error(), // For backwards compatibility
+		Error:       resp.Diagnostics.Error(),
 		Diagnostics: diagnosticsToProto(resp.Diagnostics),
-	}, resp.Diagnostics
+	}, err
 }
 
 func (g *GRPCServer) FetchResources(request *internal.FetchResources_Request, server internal.Provider_FetchResourcesServer) error {

--- a/cqproto/grpc.go
+++ b/cqproto/grpc.go
@@ -175,7 +175,7 @@ func (g *GRPCServer) ConfigureProvider(ctx context.Context, request *internal.Co
 	return &internal.ConfigureProvider_Response{
 		Error:       resp.Diagnostics.Error(), // For backwards compatibility
 		Diagnostics: diagnosticsToProto(resp.Diagnostics),
-	}, nil
+	}, resp.Diagnostics
 }
 
 func (g *GRPCServer) FetchResources(request *internal.FetchResources_Request, server internal.Provider_FetchResourcesServer) error {


### PR DESCRIPTION
Better than https://github.com/cloudquery/cq-provider-sdk/pull/228