### PR TITLE
feat: Improved execution logging

### DIFF
--- a/cqproto/internal/plugin.pb.go
+++ b/cqproto/internal/plugin.pb.go
@@ -7,10 +7,11 @@
 package internal
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/cqproto/internal/plugin_grpc.pb.go
+++ b/cqproto/internal/plugin_grpc.pb.go
@@ -4,6 +4,7 @@ package internal
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/provider/execution/execution.go
+++ b/provider/execution/execution.go
@@ -265,7 +265,9 @@ func (e TableExecutor) callTableResolve(ctx context.Context, client schema.Clien
 		if len(objects) == 0 {
 			continue
 		}
+		e.Logger.Debug("received resources from resolver", "count", len(objects))
 		resolvedCount, dd := e.resolveResources(ctx, client, parent, objects)
+		e.Logger.Debug("resolved resources", "original_count", len(objects), "resolved_count", resolvedCount)
 		// append any diags from resolve resources
 		diags = diags.Add(dd)
 		nc += resolvedCount
@@ -311,6 +313,7 @@ func (e TableExecutor) resolveResources(ctx context.Context, meta schema.ClientM
 	// only top level tables should cascade
 	shouldCascade := parent == nil
 	resources, dbDiags := e.saveToStorage(ctx, resources, shouldCascade)
+	e.Logger.Debug("saved resources to storage", "resources", len(resources))
 	diags = diags.Add(dbDiags)
 	totalCount := uint64(len(resources))
 
@@ -323,6 +326,7 @@ func (e TableExecutor) resolveResources(ctx context.Context, meta schema.ClientM
 				diags = diags.Add(innerDiags)
 			}
 		}
+		e.Logger.Debug("finished resolving table relation", "relation", rel.Name)
 	}
 	return totalCount, diags
 }

--- a/provider/execution/execution.go
+++ b/provider/execution/execution.go
@@ -173,7 +173,7 @@ func (e TableExecutor) doMultiplexResolve(ctx context.Context, clients []schema.
 			defer e.Logger.Debug("releasing multiplex client", "ctx_err", ctx.Err())
 			// create client execution add all Client's implied Args to execution logger + add its unique client id, so all its execution can be
 			// identified.
-			count, resolveDiags := e.withLogger(append(c.Logger().ImpliedArgs(), "client_id", id)).callTableResolve(ctx, c, nil)
+			count, resolveDiags := e.withLogger(append(c.Logger().ImpliedArgs(), "client_id", id)...).callTableResolve(ctx, c, nil)
 			atomic.AddUint64(&totalResources, count)
 			diags <- resolveDiags
 		}(client, diagsChan, clientID)

--- a/provider/execution/execution.go
+++ b/provider/execution/execution.go
@@ -133,13 +133,13 @@ func (e TableExecutor) doMultiplexResolve(ctx context.Context, clients []schema.
 	wg := &sync.WaitGroup{}
 	for _, client := range clients {
 		// we can only limit on a granularity of a top table otherwise we can get deadlock
-		logger.Debug("trying acquire for new client", "next_id", numberOfClients+1)
+		logger.Debug("trying acquire for new client", "next_id", fmt.Sprintf("%s:%d", e.Table.Name, numberOfClients+1))
 		if err := e.goroutinesSem.Acquire(ctx, 1); err != nil {
 			diagsChan <- ClassifyError(err, diag.WithResourceName(e.ResourceName))
 			break
 		}
 		numberOfClients++
-		clientLogger := logger.With("client_id", numberOfClients)
+		clientLogger := logger.With("client_id", fmt.Sprintf("%s:%d", e.Table.Name, numberOfClients))
 		clientLogger.Debug("creating new multiplex client")
 		wg.Add(1)
 		go func(c schema.ClientMeta, diags chan<- diag.Diagnostics, lgr hclog.Logger) {

--- a/provider/execution/execution.go
+++ b/provider/execution/execution.go
@@ -87,7 +87,8 @@ func (e TableExecutor) Resolve(ctx context.Context, meta schema.ClientMeta) (uin
 		ctx, cancel = context.WithTimeout(ctx, e.timeout)
 		defer cancel()
 	}
-	return e.callTableResolve(ctx, meta.Logger(), meta, nil)
+	logger := meta.Logger().With("table", e.Table.Name, "multiplex", false)
+	return e.callTableResolve(ctx, logger, meta, nil)
 }
 
 // withTable allows to create a new TableExecutor for received *schema.Table

--- a/provider/execution/execution_test.go
+++ b/provider/execution/execution_test.go
@@ -621,7 +621,8 @@ func TestTableExecutor_resolveResourceValues(t *testing.T) {
 
 			r := schema.NewResourceData(storage.Dialect(), tc.Table, nil, tc.ResourceData, tc.MetaData, exec.executionStart)
 			// columns should be resolved from ColumnResolver functions or default functions
-			diags := exec.resolveResourceValues(context.Background(), executionClient{testlog.New(t)}, r)
+			cl := executionClient{testlog.New(t)}
+			diags := exec.resolveResourceValues(context.Background(), cl.Logger(), cl, r)
 			if tc.ExpectedDiags != nil {
 				require.True(t, diags.HasDiags())
 				if tc.ExpectedDiags != nil {

--- a/provider/execution/execution_test.go
+++ b/provider/execution/execution_test.go
@@ -622,7 +622,7 @@ func TestTableExecutor_resolveResourceValues(t *testing.T) {
 			r := schema.NewResourceData(storage.Dialect(), tc.Table, nil, tc.ResourceData, tc.MetaData, exec.executionStart)
 			// columns should be resolved from ColumnResolver functions or default functions
 			cl := executionClient{testlog.New(t)}
-			diags := exec.resolveResourceValues(context.Background(), cl.Logger(), cl, r)
+			diags := exec.resolveResourceValues(context.Background(), cl, r)
 			if tc.ExpectedDiags != nil {
 				require.True(t, diags.HasDiags())
 				if tc.ExpectedDiags != nil {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -209,7 +209,7 @@ func (p *Provider) FetchResources(ctx context.Context, request *cqproto.FetchRes
 		if !ok {
 			return fmt.Errorf("plugin %s does not provide resource %s", p.Name, resource)
 		}
-		tableExec := execution.NewTableExecutor(resource, conn, p.Logger, table, p.extraFields, request.Metadata, p.ErrorClassifier, goroutinesSem, request.Timeout)
+		tableExec := execution.NewTableExecutor(resource, conn, p.Logger.With("table", table.Name), table, p.extraFields, request.Metadata, p.ErrorClassifier, goroutinesSem, request.Timeout)
 		p.Logger.Debug("fetching table...", "provider", p.Name, "table", table.Name)
 		// Save resource aside
 		r := resource

--- a/provider/schema/meta.go
+++ b/provider/schema/meta.go
@@ -13,6 +13,10 @@ type ClientMeta interface {
 	Logger() hclog.Logger
 }
 
+type ClientIdentifier interface {
+	Identify() string
+}
+
 type Meta struct {
 	LastUpdate time.Time `json:"last_updated"`
 	FetchId    string    `json:"fetch_id,omitempty"`


### PR DESCRIPTION
Execution Logger starts with "table" -> table base implied args, on each client execution we add clients implied args + client id.
On relations we add another With arg called relation. Might require some more tweaking