### PR TITLE
feat(stats): Add heartbeat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cloudquery/faker/v3 v3.7.4
 	github.com/creasty/defaults v1.5.2
 	github.com/doug-martin/goqu/v9 v9.17.0
+	github.com/elliotchance/orderedmap v1.4.0
 	github.com/georgysavva/scany v0.2.9
 	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/golang-migrate/migrate/v4 v4.15.0

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/mitchellh/hashstructure v1.1.0
 	github.com/modern-go/reflect2 v1.0.2
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
+	github.com/segmentio/stats/v4 v4.6.3
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cast v1.4.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -336,6 +336,8 @@ github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:Htrtb
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
+github.com/elliotchance/orderedmap v1.4.0 h1:wZtfeEONCbx6in1CZyE6bELEt/vFayMvsxqI5SgsR+A=
+github.com/elliotchance/orderedmap v1.4.0/go.mod h1:wsDwEaX5jEoyhbs7x93zk2H/qv0zwuhg4inXhDkYqys=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/go.sum
+++ b/go.sum
@@ -763,6 +763,9 @@ github.com/mattn/go-sqlite3 v1.14.7/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A
 github.com/mattn/go-sqlite3 v2.0.1+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mdlayher/genetlink v0.0.0-20190313224034-60417448a851/go.mod h1:EsbsAEUEs15qC1cosAwxgCWV0Qhd8TmkxnA9Kw1Vhl4=
+github.com/mdlayher/netlink v0.0.0-20190313131330-258ea9dff42c/go.mod h1:eQB3mZE4aiYnlUsyGGCOpPETfdQq4Jhsgf1fk3cwQaA=
+github.com/mdlayher/taskstats v0.0.0-20190313225729-7cbba52ee072/go.mod h1:sGdS7A6CAETR53zkdjGkgoFlh1vSm7MtX+i8XfEsTMA=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -911,6 +914,13 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
+github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e h1:uO75wNGioszjmIzcY/tvdDYKRLVvzggtAmmJkn9j4GQ=
+github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=
+github.com/segmentio/objconv v1.0.1 h1:QjfLzwriJj40JibCV3MGSEiAoXixbp4ybhwfTB8RXOM=
+github.com/segmentio/objconv v1.0.1/go.mod h1:auayaH5k3137Cl4SoXTgrzQcuQDmvuVtZgS0fb1Ahys=
+github.com/segmentio/stats/v4 v4.6.3 h1:Eqxr1x3Ri57FXqCCvQg9WNBlKFeUf2RhrKKnUiXhZFw=
+github.com/segmentio/stats/v4 v4.6.3/go.mod h1:gycE91tyiQw6xg3MT674cVi+CfQ69qHsoNNhXG0C7YQ=
+github.com/segmentio/vpcinfo v0.1.10/go.mod h1:KEIWiWRE/KLh90mOzOY0QkFWT7ObUYLp978tICtquqU=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
@@ -1129,6 +1139,7 @@ golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190225153610-fe579d43d832/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190313220215-9f648a60d977/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/provider/execution/execution.go
+++ b/provider/execution/execution.go
@@ -13,11 +13,10 @@ import (
 	"github.com/cloudquery/cq-provider-sdk/provider/diag"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 	"github.com/cloudquery/cq-provider-sdk/stats"
-	segmentStats "github.com/segmentio/stats/v4"
-
 	"github.com/hashicorp/go-hclog"
 	"github.com/iancoleman/strcase"
 	"github.com/modern-go/reflect2"
+	segmentStats "github.com/segmentio/stats/v4"
 	"github.com/thoas/go-funk"
 	"golang.org/x/sync/semaphore"
 )

--- a/provider/execution/execution.go
+++ b/provider/execution/execution.go
@@ -211,7 +211,7 @@ func (e TableExecutor) cleanupStaleData(ctx context.Context, client schema.Clien
 
 // callTableResolve does the actual resolving of the table calling the root table's resolver and for each returned resource resolves its columns and relations.
 func (e TableExecutor) callTableResolve(ctx context.Context, client schema.ClientMeta, parent *schema.Resource) (uint64, diag.Diagnostics) {
-	clock := stats.NewClockWithObserve("callTableResolve", s.Tag{Name: "table", Value: e.Table.Name})
+	clock := stats.NewClockWithObserve("callTableResolve", s.Tag{Name: "client_id", Value: identifyClient(client)}, s.Tag{Name: "table", Value: e.Table.Name})
 	defer clock.Stop()
 
 	// set up all diagnostics to collect from resolving table

--- a/provider/execution/execution.go
+++ b/provider/execution/execution.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cloudquery/cq-provider-sdk/provider/diag"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 	"github.com/cloudquery/cq-provider-sdk/stats"
-	s "github.com/segmentio/stats/v4"
+	segmentStats "github.com/segmentio/stats/v4"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/iancoleman/strcase"
@@ -211,7 +211,7 @@ func (e TableExecutor) cleanupStaleData(ctx context.Context, client schema.Clien
 
 // callTableResolve does the actual resolving of the table calling the root table's resolver and for each returned resource resolves its columns and relations.
 func (e TableExecutor) callTableResolve(ctx context.Context, client schema.ClientMeta, parent *schema.Resource) (uint64, diag.Diagnostics) {
-	clock := stats.NewClockWithObserve("callTableResolve", s.Tag{Name: "client_id", Value: identifyClient(client)}, s.Tag{Name: "table", Value: e.Table.Name})
+	clock := stats.NewClockWithObserve("callTableResolve", segmentStats.Tag{Name: "client_id", Value: identifyClient(client)}, segmentStats.Tag{Name: "table", Value: e.Table.Name})
 	defer clock.Stop()
 
 	// set up all diagnostics to collect from resolving table

--- a/provider/execution/execution.go
+++ b/provider/execution/execution.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/iancoleman/strcase"
 	"github.com/modern-go/reflect2"
+	"github.com/segmentio/stats/v4"
 	"github.com/thoas/go-funk"
 	"golang.org/x/sync/semaphore"
 )
@@ -208,6 +209,9 @@ func (e TableExecutor) cleanupStaleData(ctx context.Context, client schema.Clien
 
 // callTableResolve does the actual resolving of the table calling the root table's resolver and for each returned resource resolves its columns and relations.
 func (e TableExecutor) callTableResolve(ctx context.Context, client schema.ClientMeta, parent *schema.Resource) (uint64, diag.Diagnostics) {
+	clock := stats.DefaultEngine.Clock("callTableResolve", stats.Tag{Name: "table", Value: e.Table.Name})
+	defer clock.Stop()
+
 	// set up all diagnostics to collect from resolving table
 	var diags diag.Diagnostics
 

--- a/provider/execution/execution.go
+++ b/provider/execution/execution.go
@@ -12,10 +12,12 @@ import (
 	"github.com/cloudquery/cq-provider-sdk/helpers"
 	"github.com/cloudquery/cq-provider-sdk/provider/diag"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
+	"github.com/cloudquery/cq-provider-sdk/stats"
+	s "github.com/segmentio/stats/v4"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/iancoleman/strcase"
 	"github.com/modern-go/reflect2"
-	"github.com/segmentio/stats/v4"
 	"github.com/thoas/go-funk"
 	"golang.org/x/sync/semaphore"
 )
@@ -209,7 +211,7 @@ func (e TableExecutor) cleanupStaleData(ctx context.Context, client schema.Clien
 
 // callTableResolve does the actual resolving of the table calling the root table's resolver and for each returned resource resolves its columns and relations.
 func (e TableExecutor) callTableResolve(ctx context.Context, client schema.ClientMeta, parent *schema.Resource) (uint64, diag.Diagnostics) {
-	clock := stats.DefaultEngine.Clock("callTableResolve", stats.Tag{Name: "table", Value: e.Table.Name})
+	clock := stats.NewClockWithObserve("callTableResolve", s.Tag{Name: "table", Value: e.Table.Name})
 	defer clock.Stop()
 
 	// set up all diagnostics to collect from resolving table

--- a/serve/debug.go
+++ b/serve/debug.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/cloudquery/cq-provider-sdk/stats"
 	"github.com/hashicorp/go-plugin"
 )
 
@@ -42,6 +43,7 @@ func DebugServe(ctx context.Context, opts *Options) (ReattachConfig, <-chan stru
 		CloseCh:          closeCh,
 	}
 
+	stats.Start(ctx, opts.Logger)
 	go serve(opts)
 
 	var config *plugin.ReattachConfig

--- a/serve/debug.go
+++ b/serve/debug.go
@@ -43,7 +43,7 @@ func DebugServe(ctx context.Context, opts *Options) (ReattachConfig, <-chan stru
 		CloseCh:          closeCh,
 	}
 
-	stats.Start(ctx, opts.Logger)
+	stats.Start(ctx, &stats.Options{Logger: opts.Logger})
 	go serve(opts)
 
 	var config *plugin.ReattachConfig

--- a/serve/debug.go
+++ b/serve/debug.go
@@ -43,7 +43,7 @@ func DebugServe(ctx context.Context, opts *Options) (ReattachConfig, <-chan stru
 		CloseCh:          closeCh,
 	}
 
-	stats.Start(ctx, &stats.Options{Logger: opts.Logger})
+	stats.Start(ctx, opts.Logger)
 	go serve(opts)
 
 	var config *plugin.ReattachConfig

--- a/serve/serve.go
+++ b/serve/serve.go
@@ -99,7 +99,7 @@ func Serve(opts *Options) {
 		})
 	}
 
-	stats.Start(context.Background(), &stats.Options{Logger: opts.Logger})
+	stats.Start(context.Background(), opts.Logger)
 	serve(opts)
 }
 

--- a/serve/serve.go
+++ b/serve/serve.go
@@ -85,7 +85,6 @@ func Serve(opts *Options) {
 		if os.Getenv("CQ_PROVIDER_DEBUG_TRACE_LOG") == "1" {
 			opts.Logger.SetLevel(hclog.Trace)
 		}
-		stats.Start(opts.Logger)
 		if err := Debug(context.Background(), opts.Name, opts); err != nil {
 			panic(fmt.Errorf("failed to run debug: %w", err))
 		}
@@ -100,8 +99,7 @@ func Serve(opts *Options) {
 		})
 	}
 
-	stats.Start(opts.Logger)
-
+	stats.Start(context.Background(), opts.Logger)
 	serve(opts)
 }
 

--- a/serve/serve.go
+++ b/serve/serve.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/cloudquery/cq-provider-sdk/cqproto"
 	"github.com/cloudquery/cq-provider-sdk/provider"
+	"github.com/cloudquery/cq-provider-sdk/stats"
+
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
@@ -47,6 +49,8 @@ type Options struct {
 }
 
 func Serve(opts *Options) {
+	defer stats.Flush()
+
 	if opts.Name == "" {
 		panic("missing provider name")
 	}
@@ -81,6 +85,7 @@ func Serve(opts *Options) {
 		if os.Getenv("CQ_PROVIDER_DEBUG_TRACE_LOG") == "1" {
 			opts.Logger.SetLevel(hclog.Trace)
 		}
+		stats.Start(opts.Logger)
 		if err := Debug(context.Background(), opts.Name, opts); err != nil {
 			panic(fmt.Errorf("failed to run debug: %w", err))
 		}
@@ -94,6 +99,8 @@ func Serve(opts *Options) {
 			JSONFormat: true,
 		})
 	}
+
+	stats.Start(opts.Logger)
 
 	serve(opts)
 }

--- a/serve/serve.go
+++ b/serve/serve.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cloudquery/cq-provider-sdk/cqproto"
 	"github.com/cloudquery/cq-provider-sdk/provider"
 	"github.com/cloudquery/cq-provider-sdk/stats"
-
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"

--- a/serve/serve.go
+++ b/serve/serve.go
@@ -99,7 +99,7 @@ func Serve(opts *Options) {
 		})
 	}
 
-	stats.Start(context.Background(), opts.Logger)
+	stats.Start(context.Background(), &stats.Options{Logger: opts.Logger})
 	serve(opts)
 }
 

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -1,36 +1,80 @@
 package stats
 
 import (
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/segmentio/stats/v4"
 )
 
-type Measures struct {
-	measures []stats.Measure
-	time     time.Time
+type Measure struct {
+	id    string
+	value stats.Value
+	stamp bool
+	time  time.Time
 }
+
+type Stat struct {
+	Start    time.Time
+	Duration int64
+}
+
 type LogHandler struct {
 	logger   hclog.Logger
-	measures chan Measures
+	measures chan Measure
+	stats    map[string]Stat
+}
+
+func NewClockWithObserve(name string, tags ...stats.Tag) *stats.Clock {
+	now := time.Now()
+	cl := stats.DefaultEngine.ClockAt(name, now, tags...)
+	stats.DefaultEngine.Observe(name, now, tags...)
+	return cl
+}
+
+func meta(name string, tags []stats.Tag) (string, bool) {
+	var stamp = false
+	var s []string
+	s = append(s, name)
+	for _, t := range tags {
+		// stamp is added on clock.Stop()
+		// we want that both clock.Start() and clock.Stop() have the same map id
+		if t.Name != "stamp" {
+			s = append(s, t.Name, t.Value)
+		} else {
+			stamp = true
+		}
+	}
+	return strings.Join(s, ":"), stamp
 }
 
 func (h *LogHandler) HandleMeasures(time time.Time, measures ...stats.Measure) {
-	h.measures <- Measures{measures: measures, time: time}
+	for _, m := range measures {
+		id, stamp := meta(m.Name, m.Tags)
+		h.measures <- Measure{id: id, value: m.Fields[0].Value, time: time, stamp: stamp}
+	}
 }
 
 func (h *LogHandler) Flush() {
 	for m := range h.measures {
-		h.logger.Debug("heartbeat", "time", m.time, "measures", m)
+		if m.stamp {
+			if m.stamp {
+				item := h.stats[m.id]
+				item.Duration = m.value.Int()
+			} else {
+				h.stats[m.id] = Stat{Start: m.time}
+			}
+		}
 	}
 }
 
 func newHandler(logger hclog.Logger) stats.Handler {
-	return &LogHandler{logger: logger, measures: make(chan Measures)}
+	return &LogHandler{logger: logger, measures: make(chan Measure), stats: make(map[string]Stat)}
 }
 
 func Start(logger hclog.Logger) {
+	stats.DefaultEngine.Prefix = ""
 	stats.Register(newHandler(logger))
 
 	go func() {

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -71,11 +72,11 @@ func (h *durationLogger) Flush() {
 		if stat.stopped {
 			// `clock.Stop` was called, so we log the total duration and remove the operation from future logs
 			durationReported = append(durationReported, id.(string))
-			h.logger.Debug("heartbeat", "id", id, "duration", int64(stat.duration.Round(time.Second).Seconds()))
+			h.logger.Debug("heartbeat", "id", id, "duration", printSeconds(stat.duration))
 		} else {
 			// `clock.Stop` was not called, so the operation is still running
 			// We log the duration since the start of the operation
-			h.logger.Debug("heartbeat", "id", id, "running_for", time.Since(stat.start).Round(time.Second).String())
+			h.logger.Debug("heartbeat", "id", id, "running_for", printSeconds(time.Since(stat.start)))
 		}
 	}
 
@@ -143,4 +144,8 @@ func getMeasurementDetails(name string, tags []stats.Tag) (string, bool) {
 		}
 	}
 	return strings.Join(s, ":"), stamp
+}
+
+func printSeconds(duration time.Duration) string {
+	return fmt.Sprintf("%ds", int64(duration.Seconds()))
 }

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -71,7 +71,7 @@ func (h *durationLogger) Flush() {
 		if stat.stopped {
 			// `clock.Stop` was called, so we log the total duration and remove the operation from future logs
 			durationReported = append(durationReported, id.(string))
-			h.logger.Debug("heartbeat", "id", id, "duration", stat.duration.Round(time.Second).String())
+			h.logger.Debug("heartbeat", "id", id, "duration", int64(stat.duration.Round(time.Second).Seconds()))
 		} else {
 			// `clock.Stop` was not called, so the operation is still running
 			// We log the duration since the start of the operation

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -1,0 +1,45 @@
+package stats
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/segmentio/stats/v4"
+)
+
+type Measures struct {
+	measures []stats.Measure
+	time     time.Time
+}
+type LogHandler struct {
+	logger   hclog.Logger
+	measures chan Measures
+}
+
+func (h *LogHandler) HandleMeasures(time time.Time, measures ...stats.Measure) {
+	h.measures <- Measures{measures: measures, time: time}
+}
+
+func (h *LogHandler) Flush() {
+	for m := range h.measures {
+		h.logger.Debug("heartbeat", "time", m.time, "measures", m)
+	}
+}
+
+func newHandler(logger hclog.Logger) stats.Handler {
+	return &LogHandler{logger: logger, measures: make(chan Measures)}
+}
+
+func Start(logger hclog.Logger) {
+	stats.Register(newHandler(logger))
+
+	go func() {
+		for range time.Tick(time.Second * 30) {
+			stats.Flush()
+		}
+	}()
+}
+
+func Flush() {
+	stats.Flush()
+}

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -126,7 +126,7 @@ func newHandler(logger hclog.Logger) stats.Handler {
 
 func meta(name string, tags []stats.Tag) (string, bool) {
 	var stamp = false
-	var s []string
+	s := make([]string, 0, len(tags))
 	s = append(s, name)
 	for _, t := range tags {
 		// stamp is added on `clock.Stop()`

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -113,7 +113,7 @@ func Start(ctx context.Context, opts *Options) {
 	stats.DefaultEngine.Prefix = ""
 
 	if opts.Tick == 0 {
-		opts.Tick = time.Second * 30
+		opts.Tick = time.Minute
 	}
 
 	if opts.Handler == nil {

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -61,7 +61,7 @@ func (h *logHandler) Flush() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	durationReported := make([]string, 0)
+	var durationReported []string
 	for el := h.trackedOperations.Front(); el != nil; el = el.Next() {
 		id := el.Key
 		stat := el.Value.(stat)

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -11,17 +11,6 @@ import (
 	"github.com/segmentio/stats/v4"
 )
 
-const (
-	bufferSize = 100
-)
-
-type measure struct {
-	id       string
-	duration time.Duration
-	stamp    bool
-	time     time.Time
-}
-
 type stat struct {
 	Start    time.Time
 	Duration time.Duration
@@ -29,7 +18,6 @@ type stat struct {
 
 type logHandler struct {
 	logger            hclog.Logger
-	measures          chan measure
 	trackedOperations *orderedmap.OrderedMap
 	mu                sync.Mutex
 }
@@ -69,9 +57,18 @@ func meta(name string, tags []stats.Tag) (string, bool) {
 // Or by `clock.Stop` which indicates a "stop" of an operation
 // We pass the measurements to a channel and periodically aggregate the data and print a hearbeat log
 func (h *logHandler) HandleMeasures(time time.Time, measures ...stats.Measure) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	for _, m := range measures {
 		id, stamp := meta(m.Fields[0].Name, m.Tags)
-		h.measures <- measure{id: id, duration: m.Fields[0].Value.Duration(), time: time, stamp: stamp}
+		if stamp {
+			item, ok := h.trackedOperations.Get(id)
+			if ok {
+				h.trackedOperations.Set(id, stat{Start: item.(stat).Start, Duration: m.Fields[0].Value.Duration()})
+			}
+		} else {
+			h.trackedOperations.Set(id, stat{Start: time, Duration: 0})
+		}
 	}
 }
 
@@ -79,24 +76,6 @@ func (h *logHandler) HandleMeasures(time time.Time, measures ...stats.Measure) {
 func (h *logHandler) Flush() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-
-	hasItems := true
-	for hasItems {
-		select {
-		case m := <-h.measures:
-			// We group start and stop measurements. Stop means `clock.Stop` was called for the operation
-			if m.stamp {
-				item, ok := h.trackedOperations.Get(m.id)
-				if ok {
-					h.trackedOperations.Set(m.id, stat{Start: item.(stat).Start, Duration: m.duration})
-				}
-			} else {
-				h.trackedOperations.Set(m.id, stat{Start: m.time, Duration: 0})
-			}
-		default:
-			hasItems = false
-		}
-	}
 
 	durationReported := make([]string, 0)
 	for el := h.trackedOperations.Front(); el != nil; el = el.Next() {
@@ -158,5 +137,5 @@ func Flush() {
 }
 
 func newHandler(logger hclog.Logger) stats.Handler {
-	return &logHandler{logger: logger, measures: make(chan measure, bufferSize), trackedOperations: orderedmap.NewOrderedMap()}
+	return &logHandler{logger: logger, trackedOperations: orderedmap.NewOrderedMap()}
 }

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -93,6 +93,8 @@ func Start(ctx context.Context, logger hclog.Logger, options ...func(*Options)) 
 		o(opts)
 	}
 
+	logger.Debug("starting stats collector heartbeat", "tick", opts.tick)
+
 	stats.Register(opts.handler)
 
 	go func() {

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -119,15 +119,12 @@ func (h *logHandler) Flush() {
 	}
 }
 
-func Start(ctx context.Context, opts *Options) {
+func Start(ctx context.Context, logger hclog.Logger, options ...func(*Options)) {
 	stats.DefaultEngine.Prefix = ""
 
-	if opts.Tick == 0 {
-		opts.Tick = time.Minute
-	}
-
-	if opts.Handler == nil {
-		opts.Handler = newHandler(opts.Logger)
+	opts := &Options{Tick: time.Minute, Handler: newHandler(logger)}
+	for _, o := range options {
+		o(opts)
 	}
 
 	stats.Register(opts.Handler)
@@ -143,6 +140,18 @@ func Start(ctx context.Context, opts *Options) {
 			}
 		}
 	}()
+}
+
+func WithTick(tick time.Duration) func(*Options) {
+	return func(opts *Options) {
+		opts.Tick = tick
+	}
+}
+
+func WithHandler(handler stats.Handler) func(*Options) {
+	return func(opts *Options) {
+		opts.Handler = handler
+	}
 }
 
 func Flush() {

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -93,11 +93,12 @@ func Start(ctx context.Context, logger hclog.Logger, options ...func(*Options)) 
 
 	go func() {
 		ticker := time.NewTicker(opts.tick)
-		for range ticker.C {
+		defer ticker.Stop()
+		for {
 			select {
 			case <-ctx.Done():
 				return
-			default:
+			case <-ticker.C:
 				stats.Flush()
 			}
 		}

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -126,7 +126,7 @@ func newHandler(logger hclog.Logger) stats.Handler {
 
 func meta(name string, tags []stats.Tag) (string, bool) {
 	var stamp = false
-	s := make([]string, 0, len(tags))
+	s := make([]string, 1, len(tags))
 	s = append(s, name)
 	for _, t := range tags {
 		// stamp is added on `clock.Stop()`

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -72,11 +72,11 @@ func (h *durationLogger) Flush() {
 		if stat.stopped {
 			// `clock.Stop` was called, so we log the total duration and remove the operation from future logs
 			durationReported = append(durationReported, id.(string))
-			h.logger.Debug("heartbeat", "id", id, "duration", printSeconds(stat.duration))
+			h.logger.Debug("heartbeat", "id", id, "duration", formatSeconds(stat.duration))
 		} else {
 			// `clock.Stop` was not called, so the operation is still running
 			// We log the duration since the start of the operation
-			h.logger.Debug("heartbeat", "id", id, "running_for", printSeconds(time.Since(stat.start)))
+			h.logger.Debug("heartbeat", "id", id, "running_for", formatSeconds(time.Since(stat.start)))
 		}
 	}
 
@@ -146,6 +146,6 @@ func getMeasurementDetails(name string, tags []stats.Tag) (string, bool) {
 	return strings.Join(s, ":"), stamp
 }
 
-func printSeconds(duration time.Duration) string {
+func formatSeconds(duration time.Duration) string {
 	return fmt.Sprintf("%ds", int64(duration.Seconds()))
 }

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -52,7 +52,7 @@ func (h *durationLogger) HandleMeasures(time time.Time, measures ...stats.Measur
 				h.trackedOperations.Set(id, stat{start: item.(stat).start, duration: m.Fields[0].Value.Duration(), stopped: true})
 			}
 		} else {
-			h.trackedOperations.Set(id, stat{start: time, duration: 0, stopped: false})
+			h.trackedOperations.Set(id, stat{start: time})
 		}
 	}
 }

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -16,7 +16,7 @@ type stat struct {
 	Duration time.Duration
 }
 
-type logHandler struct {
+type durationLogger struct {
 	logger            hclog.Logger
 	trackedOperations *orderedmap.OrderedMap
 	mu                sync.Mutex
@@ -40,7 +40,7 @@ func NewClockWithObserve(name string, tags ...stats.Tag) *stats.Clock {
 // HandleMeasures can be called by `NewClockWithObserve` which indicates a "start" of an operation
 // Or by `clock.Stop` which indicates a "stop" of an operation
 // We pass the measurements to a channel and periodically aggregate the data and print a hearbeat log
-func (h *logHandler) HandleMeasures(time time.Time, measures ...stats.Measure) {
+func (h *durationLogger) HandleMeasures(time time.Time, measures ...stats.Measure) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	for _, m := range measures {
@@ -57,7 +57,7 @@ func (h *logHandler) HandleMeasures(time time.Time, measures ...stats.Measure) {
 }
 
 // This is executed in the context of the tick go routine
-func (h *logHandler) Flush() {
+func (h *durationLogger) Flush() {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -122,7 +122,7 @@ func Flush() {
 }
 
 func newHandler(logger hclog.Logger) stats.Handler {
-	return &logHandler{logger: logger, trackedOperations: orderedmap.NewOrderedMap()}
+	return &durationLogger{logger: logger, trackedOperations: orderedmap.NewOrderedMap()}
 }
 
 func meta(name string, tags []stats.Tag) (string, bool) {

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -44,7 +44,7 @@ func (h *durationLogger) HandleMeasures(time time.Time, measures ...stats.Measur
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	for _, m := range measures {
-		id, stamp := meta(m.Fields[0].Name, m.Tags)
+		id, stamp := getMeasurementDetails(m.Fields[0].Name, m.Tags)
 		if stamp {
 			item, ok := h.trackedOperations.Get(id)
 			if ok {
@@ -125,7 +125,7 @@ func newHandler(logger hclog.Logger) stats.Handler {
 	return &durationLogger{logger: logger, trackedOperations: orderedmap.NewOrderedMap()}
 }
 
-func meta(name string, tags []stats.Tag) (string, bool) {
+func getMeasurementDetails(name string, tags []stats.Tag) (string, bool) {
 	var stamp = false
 	s := make([]string, 1, len(tags))
 	s = append(s, name)

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -35,22 +35,6 @@ func NewClockWithObserve(name string, tags ...stats.Tag) *stats.Clock {
 	return cl
 }
 
-func meta(name string, tags []stats.Tag) (string, bool) {
-	var stamp = false
-	var s []string
-	s = append(s, name)
-	for _, t := range tags {
-		// stamp is added on `clock.Stop()`
-		// we want that both `clock.Start()` and `clock.Stop()` have the same map id
-		if t.Name != "stamp" {
-			s = append(s, t.Name, t.Value)
-		} else {
-			stamp = true
-		}
-	}
-	return strings.Join(s, ":"), stamp
-}
-
 // This is executed in the context of the calling method
 // We would like to keep track of still running operations, and completed operations durations
 // HandleMeasures can be called by `NewClockWithObserve` which indicates a "start" of an operation
@@ -138,4 +122,20 @@ func Flush() {
 
 func newHandler(logger hclog.Logger) stats.Handler {
 	return &logHandler{logger: logger, trackedOperations: orderedmap.NewOrderedMap()}
+}
+
+func meta(name string, tags []stats.Tag) (string, bool) {
+	var stamp = false
+	var s []string
+	s = append(s, name)
+	for _, t := range tags {
+		// stamp is added on `clock.Stop()`
+		// we want that both `clock.Start()` and `clock.Stop()` have the same map id
+		if t.Name != "stamp" {
+			s = append(s, t.Name, t.Value)
+		} else {
+			stamp = true
+		}
+	}
+	return strings.Join(s, ":"), stamp
 }

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -35,9 +35,8 @@ type logHandler struct {
 }
 
 type Options struct {
-	Logger  hclog.Logger
-	Tick    time.Duration
-	Handler stats.Handler
+	tick    time.Duration
+	handler stats.Handler
 }
 
 func NewClockWithObserve(name string, tags ...stats.Tag) *stats.Clock {
@@ -122,15 +121,15 @@ func (h *logHandler) Flush() {
 func Start(ctx context.Context, logger hclog.Logger, options ...func(*Options)) {
 	stats.DefaultEngine.Prefix = ""
 
-	opts := &Options{Tick: time.Minute, Handler: newHandler(logger)}
+	opts := &Options{tick: time.Minute, handler: newHandler(logger)}
 	for _, o := range options {
 		o(opts)
 	}
 
-	stats.Register(opts.Handler)
+	stats.Register(opts.handler)
 
 	go func() {
-		ticker := time.NewTicker(opts.Tick)
+		ticker := time.NewTicker(opts.tick)
 		for range ticker.C {
 			select {
 			case <-ctx.Done():
@@ -144,13 +143,13 @@ func Start(ctx context.Context, logger hclog.Logger, options ...func(*Options)) 
 
 func WithTick(tick time.Duration) func(*Options) {
 	return func(opts *Options) {
-		opts.Tick = tick
+		opts.tick = tick
 	}
 }
 
 func WithHandler(handler stats.Handler) func(*Options) {
 	return func(opts *Options) {
-		opts.Handler = handler
+		opts.handler = handler
 	}
 }
 

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -130,7 +130,7 @@ func newHandler(logger hclog.Logger) stats.Handler {
 
 func getMeasurementDetails(name string, tags []stats.Tag) (string, bool) {
 	var stamp = false
-	s := make([]string, 1, len(tags))
+	s := make([]string, 0, len(tags))
 	s = append(s, name)
 	for _, t := range tags {
 		// stamp is added on `clock.Stop()`

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -42,7 +42,7 @@ func NewClockWithObserve(name string, tags ...stats.Tag) *stats.Clock {
 // HandleMeasures can be called by `NewClockWithObserve` which indicates a "start" of an operation
 // Or by `clock.Stop` which indicates a "stop" of an operation
 // We pass the measurements to a channel and periodically aggregate the data and print a hearbeat log
-func (h *durationLogger) HandleMeasures(time time.Time, measures ...stats.Measure) {
+func (h *durationLogger) HandleMeasures(t time.Time, measures ...stats.Measure) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	for _, m := range measures {
@@ -53,7 +53,7 @@ func (h *durationLogger) HandleMeasures(time time.Time, measures ...stats.Measur
 				h.trackedOperations.Set(id, stat{start: item.(stat).start, duration: m.Fields[0].Value.Duration(), stopped: true})
 			}
 		} else {
-			h.trackedOperations.Set(id, stat{start: time})
+			h.trackedOperations.Set(id, stat{start: t})
 		}
 	}
 }

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -37,7 +37,7 @@ func Test_meta(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			id, stamp := meta(tt.args.name, tt.args.tags)
+			id, stamp := getMeasurementDetails(tt.args.name, tt.args.tags)
 			assert.EqualValues(t, tt.want.id, id)
 			assert.EqualValues(t, tt.want.stamp, stamp)
 		})

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_meta(t *testing.T) {
+func Test_getMeasurementDetails(t *testing.T) {
 	type args struct {
 		name string
 		tags []stats.Tag

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -55,7 +55,7 @@ func TestLogHandler(t *testing.T) {
 	NewClockWithObserve("withoutStop", stats.Tag{Name: "table", Value: "table2"})
 	Flush()
 
-	logHandler := handler.(*LogHandler)
+	logHandler := handler.(*logHandler)
 	assert.Len(t, logHandler.stats.Keys(), 2)
 	assert.EqualValues(t, "withStop:table:table1", logHandler.stats.Keys()[0])
 	assert.EqualValues(t, "withoutStop:table:table2", logHandler.stats.Keys()[1])

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -1,0 +1,71 @@
+package stats
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/segmentio/stats/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_meta(t *testing.T) {
+	type args struct {
+		name string
+		tags []stats.Tag
+	}
+	type want struct {
+		id    string
+		stamp bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "Non stamped clock",
+			args: args{name: "measurement", tags: []stats.Tag{{Name: "table", Value: "name_of_table"}}},
+			want: want{id: "measurement:table:name_of_table", stamp: false},
+		},
+		{
+			name: "Stamped clock",
+			args: args{name: "measurement", tags: []stats.Tag{{Name: "table", Value: "name_of_table"}, {Name: "stamp", Value: "total"}}},
+			want: want{id: "measurement:table:name_of_table", stamp: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, stamp := meta(tt.args.name, tt.args.tags)
+			assert.EqualValues(t, tt.want.id, id)
+			assert.EqualValues(t, tt.want.stamp, stamp)
+		})
+	}
+}
+
+func TestLogHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	logger := hclog.NewNullLogger()
+	handler := newHandler(logger)
+	Start(ctx, &Options{Logger: logger, Tick: time.Hour, Handler: handler})
+
+	clock1 := NewClockWithObserve("withStop", stats.Tag{Name: "table", Value: "table1"})
+	NewClockWithObserve("withoutStop", stats.Tag{Name: "table", Value: "table2"})
+	Flush()
+
+	logHandler := handler.(*LogHandler)
+	assert.Len(t, logHandler.stats.Keys(), 2)
+	assert.EqualValues(t, "withStop:table:table1", logHandler.stats.Keys()[0])
+	assert.EqualValues(t, "withoutStop:table:table2", logHandler.stats.Keys()[1])
+	clock1.Stop()
+
+	Flush()
+
+	assert.Len(t, logHandler.stats.Keys(), 1)
+	assert.EqualValues(t, "withoutStop:table:table2", logHandler.stats.Keys()[0])
+
+	cancel()
+
+}

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -55,7 +55,7 @@ func TestLogHandler(t *testing.T) {
 	NewClockWithObserve("withoutStop", stats.Tag{Name: "table", Value: "table2"})
 	Flush()
 
-	logHandler := handler.(*logHandler)
+	logHandler := handler.(*durationLogger)
 	assert.Len(t, logHandler.trackedOperations.Keys(), 2)
 	assert.EqualValues(t, "withStop:table:table1", logHandler.trackedOperations.Keys()[0])
 	assert.EqualValues(t, "withoutStop:table:table2", logHandler.trackedOperations.Keys()[1])

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -56,15 +56,15 @@ func TestLogHandler(t *testing.T) {
 	Flush()
 
 	logHandler := handler.(*logHandler)
-	assert.Len(t, logHandler.stats.Keys(), 2)
-	assert.EqualValues(t, "withStop:table:table1", logHandler.stats.Keys()[0])
-	assert.EqualValues(t, "withoutStop:table:table2", logHandler.stats.Keys()[1])
+	assert.Len(t, logHandler.trackedOperations.Keys(), 2)
+	assert.EqualValues(t, "withStop:table:table1", logHandler.trackedOperations.Keys()[0])
+	assert.EqualValues(t, "withoutStop:table:table2", logHandler.trackedOperations.Keys()[1])
 	clock1.Stop()
 
 	Flush()
 
-	assert.Len(t, logHandler.stats.Keys(), 1)
-	assert.EqualValues(t, "withoutStop:table:table2", logHandler.stats.Keys()[0])
+	assert.Len(t, logHandler.trackedOperations.Keys(), 1)
+	assert.EqualValues(t, "withoutStop:table:table2", logHandler.trackedOperations.Keys()[0])
 
 	cancel()
 

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -49,7 +49,7 @@ func TestLogHandler(t *testing.T) {
 
 	logger := hclog.NewNullLogger()
 	handler := newHandler(logger)
-	Start(ctx, &Options{Logger: logger, Tick: time.Hour, Handler: handler})
+	Start(ctx, logger, WithTick(time.Hour), WithHandler(handler))
 
 	clock1 := NewClockWithObserve("withStop", stats.Tag{Name: "table", Value: "table1"})
 	NewClockWithObserve("withoutStop", stats.Tag{Name: "table", Value: "table2"})

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -67,5 +67,4 @@ func TestLogHandler(t *testing.T) {
 	assert.EqualValues(t, "withoutStop:table:table2", logHandler.trackedOperations.Keys()[0])
 
 	cancel()
-
 }


### PR DESCRIPTION
~~Draft PR on how we could implement heartbeat with different stats~~

Fixes https://github.com/cloudquery/cloudquery/issues/708

Uses [segment stats library](https://github.com/segmentio/stats) to measure durations. Only added a single measurement in `callTableResolve`, but it's easy to add more. Future improvements can be logging to console slow resources, sending information to [datadog](https://github.com/segmentio/stats#engine), etc

Example log for still running operation:
```
{"@level":"debug","@message":"heartbeat","@module":"aws","@timestamp":"2022-05-15T15:49:19.377174+03:00","id":"callTableResolve:client_id:6157xxxxxxxx:eu-north-1:table:aws_iam_roles","running_for":"2m2s"}
```

After the operation is done:
```
{"@level":"debug","@message":"heartbeat","@module":"aws","@timestamp":"2022-05-15T15:49:49.372747+03:00","duration":"2m9s","id":"callTableResolve:client_id:6157xxxxxxxx:eu-north-1:table:aws_iam_roles"}
```