### PR TITLE
fix(deps): Update hashstructure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451
 	github.com/jackc/pgtype v1.8.1
 	github.com/jackc/pgx/v4 v4.13.0
-	github.com/mitchellh/hashstructure v1.1.0
+	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/modern-go/reflect2 v1.0.2
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/spf13/afero v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -772,8 +772,8 @@ github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
-github.com/mitchellh/hashstructure v1.1.0 h1:P6P1hdjqAAknpY/M1CGipelZgp+4y9ja9kmUZPXP+H0=
-github.com/mitchellh/hashstructure v1.1.0/go.mod h1:xUDAozZz0Wmdiufv0uyhnHkUTN6/6d8ulp4AwfLKrmA=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/mapstructure v0.0.0-20180220230111-00c29f56e238/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=

--- a/provider/schema/resource.go
+++ b/provider/schema/resource.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/mitchellh/hashstructure"
+	"github.com/mitchellh/hashstructure/v2"
 	"github.com/thoas/go-funk"
 )
 
@@ -175,7 +175,7 @@ func hashUUID(objs interface{}) (uuid.UUID, error) {
 	// Use SHA1 because it's fast and is reasonably enough protected against accidental collisions.
 	// There is no scenario here where intentional created collisions could do harm.
 	digester := crypto.SHA1.New()
-	hash, err := hashstructure.Hash(objs, nil)
+	hash, err := hashstructure.Hash(objs, hashstructure.FormatV2, nil)
 	if err != nil {
 		return uuid.Nil, err
 	}


### PR DESCRIPTION
Related to https://github.com/cloudquery/cloudquery-issues/issues/336 (internal issue).

We've seen the following error pop up from time to time:
```
failed to insert to table "aws_ec2_internet_gateway_attachments": ERROR: duplicate key value violates unique constraint "aws_ec2_internet_gateway_attachments_pk"
```

The reason is probably concurrent fetches, however the version we're using of `hashstructure` has a bug that can cause hash collisions. It was fixed in v2 https://github.com/mitchellh/hashstructure/tree/a045b665615f739329536a58c25ca6327abf1ec1#installation