### PR TITLE
fix: Use hashing FormatV1

### DIFF
--- a/provider/schema/resource.go
+++ b/provider/schema/resource.go
@@ -175,7 +175,8 @@ func hashUUID(objs interface{}) (uuid.UUID, error) {
 	// Use SHA1 because it's fast and is reasonably enough protected against accidental collisions.
 	// There is no scenario here where intentional created collisions could do harm.
 	digester := crypto.SHA1.New()
-	hash, err := hashstructure.Hash(objs, hashstructure.FormatV2, nil)
+	// TODO: Use FormatV2 once we drop db migrations
+	hash, err := hashstructure.Hash(objs, hashstructure.FormatV1, nil)
 	if err != nil {
 		return uuid.Nil, err
 	}


### PR DESCRIPTION
Reverts https://github.com/cloudquery/cq-provider-sdk/pull/252 until we drop migrations and can upgrade to the new hashing format