### PR TITLE
feat: Always use BigInt

### DIFF
--- a/provider/schema/column.go
+++ b/provider/schema/column.go
@@ -98,12 +98,8 @@ func (v ValueType) String() string {
 	switch v {
 	case TypeBool:
 		return "TypeBool"
-	case TypeBigInt:
+	case TypeInt, TypeBigInt, TypeSmallInt:
 		return "TypeBigInt"
-	case TypeSmallInt:
-		return "TypeSmallInt"
-	case TypeInt:
-		return "TypeInt"
 	case TypeFloat:
 		return "TypeFloat"
 	case TypeUUID:
@@ -141,16 +137,13 @@ func (v ValueType) String() string {
 	}
 }
 
+// ValueTypeFromString this function is mainly used by https://github.com/cloudquery/cq-gen
 func ValueTypeFromString(s string) ValueType {
 	switch strings.ToLower(s) {
 	case "bool", "TypeBool":
 		return TypeBool
-	case "int", "TypeInt":
-		return TypeInt
-	case "bigint", "TypeBigInt":
+	case "int", "TypeInt", "bigint", "TypeBigInt", "smallint", "TypeSmallInt":
 		return TypeBigInt
-	case "smallint", "TypeSmallInt":
-		return TypeSmallInt
 	case "float", "TypeFloat":
 		return TypeFloat
 	case "uuid", "TypeUUID":
@@ -214,12 +207,9 @@ func (c Column) checkType(v interface{}) bool {
 	}
 
 	switch val := v.(type) {
-	case int8, *int8, uint8, *uint8, int16, *int16:
-		return c.Type == TypeSmallInt
-	case uint16, int32, *int32:
-		return c.Type == TypeInt
-	case int, *int, uint32, *uint32, int64, *int64:
-		return c.Type == TypeBigInt || c.Type == TypeInt
+	case int8, *int8, uint8, *uint8, int16, *int16, uint16, *uint16, int32, *int32, int, *int, uint32, *uint32, int64, *int64:
+		// TODO: Deprecate all Int Types in favour of BigInt
+		return c.Type == TypeBigInt || c.Type == TypeSmallInt || c.Type == TypeInt
 	case []byte:
 		if c.Type == TypeUUID {
 			if _, err := uuid.FromBytes(val); err != nil {


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

This is a pre-step to supporting only `TypeBigInt`. we don't need necessarly to remove this as this will break a bit of backward compatibility but at least right now we shouldn't have any int mismatch errors as we always use BigInt.

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
