### PR TITLE
fix: Use errgroup SetLimit

### DIFF
--- a/helpers/integers.go
+++ b/helpers/integers.go
@@ -10,3 +10,10 @@ func Uint64ToInt64(i uint64) int64 {
 	}
 	return int64(i)
 }
+
+func Uint64ToInt(i uint64) int {
+	if i > math.MaxInt {
+		return math.MaxInt
+	}
+	return int(i)
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -186,14 +186,10 @@ func (p *Provider) FetchResources(ctx context.Context, request *cqproto.FetchRes
 	p.Logger.Info("calculated max goroutines for fetch execution", "max_goroutines", maxGoroutines)
 	goroutinesSem = semaphore.NewWeighted(helpers.Uint64ToInt64(maxGoroutines))
 
-	// limiter used to limit the amount of resources fetched concurrently
-	var parallelResourceSem *semaphore.Weighted
-	maxParallelFetchingLimit := request.ParallelFetchingLimit
-	if maxParallelFetchingLimit > 0 {
-		parallelResourceSem = semaphore.NewWeighted(helpers.Uint64ToInt64(maxParallelFetchingLimit))
-	}
-
 	g, gctx := errgroup.WithContext(ctx)
+	if request.ParallelFetchingLimit > 0 {
+		g.SetLimit(helpers.Uint64ToInt(request.ParallelFetchingLimit))
+	}
 	finishedResources := make(map[string]bool, len(resources))
 	l := &sync.Mutex{}
 	var totalResourceCount uint64
@@ -209,15 +205,7 @@ func (p *Provider) FetchResources(ctx context.Context, request *cqproto.FetchRes
 		l.Lock()
 		finishedResources[r] = false
 		l.Unlock()
-		if parallelResourceSem != nil {
-			if err := parallelResourceSem.Acquire(ctx, 1); err != nil {
-				return err
-			}
-		}
 		g.Go(func() error {
-			if parallelResourceSem != nil {
-				defer parallelResourceSem.Release(1)
-			}
 			resourceCount, diags := tableExec.Resolve(gctx, p.meta)
 			l.Lock()
 			defer l.Unlock()


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

With [sync package update](https://github.com/cloudquery/cq-provider-sdk/pull/345) `errgroup` has support for setting a limit.
We should be able to do the same in other repositories.
Still need to test it a bit.

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
