### PR TITLE
refactor: Use range with values in `fromErr`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 config.hcl
 
 .vscode
+vendor

--- a/provider/execution/errors.go
+++ b/provider/execution/errors.go
@@ -44,15 +44,16 @@ func WithResource(resource *schema.Resource) diag.BaseErrorOption {
 }
 
 func fromError(err error, opts ...diag.BaseErrorOption) diag.Diagnostics {
+	baseOpts := append([]diag.BaseErrorOption{diag.WithNoOverwrite()}, opts...)
 	switch ti := err.(type) {
 	case diag.Diagnostics:
-		ret := make(diag.Diagnostics, len(ti))
-		for i := range ti {
-			ret[i] = diag.NewBaseError(ti[i], diag.RESOLVING, append([]diag.BaseErrorOption{diag.WithNoOverwrite()}, opts...)...)
+		ret := make(diag.Diagnostics, 0, len(ti))
+		for _, d := range ti {
+			ret = append(ret, diag.NewBaseError(d, diag.RESOLVING, baseOpts...))
 		}
 		return ret
 	default:
-		e := diag.NewBaseError(err, diag.RESOLVING, append([]diag.BaseErrorOption{diag.WithNoOverwrite()}, opts...)...)
+		e := diag.NewBaseError(err, diag.RESOLVING, baseOpts...)
 		return diag.Diagnostics{e}
 	}
 }


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

A small refactoring of `fromErr` function.

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
