### PR TITLE
fix: Issues when PG username is 'cloudquery'

### DIFF
--- a/database/postgres/connection.go
+++ b/database/postgres/connection.go
@@ -16,6 +16,11 @@ func Connect(ctx context.Context, dsnURI string) (*pgxpool.Pool, error) {
 		return nil, dsn.RedactParseError(err)
 	}
 	poolCfg.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		_, err := conn.Exec(ctx, "SET search_path=public")
+		if err != nil {
+			return err
+		}
+
 		UUIDType := pgtype.DataType{
 			Value: &UUID{},
 			Name:  "uuid",


### PR DESCRIPTION
Before this fix, cloudquery misbehaved when the PG username was named 'cloudquery'.
It created tables in the 'cloudquery' schema instead of the 'public' schema.
This happened because the search path was  '"$user", public', which means it depended on the username.

This fix, upon connection to PG, will change serach_path to 'public' only, i.e. not dependent on username (which is way more predictable).

This won't impact us explicitly accessing the 'cloudquery' schema via 'cloudquery.<table-name>', which is what we do when we actually need the 'cloudquery' schema.

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

closes: https://github.com/cloudquery/cloudquery/issues/901.

#### Summary

<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/.github/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
