### PR TITLE
fix: Put example YAML from the provider in `configuration` block

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -110,9 +110,27 @@ func (p *Provider) GetProviderConfig(_ context.Context, req *cqproto.GetProvider
 			// HeadComment doesn't work here
 			Content: []*yaml.Node{
 				{
-					Kind: yaml.ScalarNode,
-					// double newline will leave only the last block of comments
-					HeadComment: strings.TrimRight(providerConfig.Example(), "\r\n") + "\n \nlist of resources to fetch",
+					Kind:  yaml.ScalarNode,
+					Value: "configuration",
+				},
+				{
+					Kind:        yaml.MappingNode,
+					HeadComment: strings.TrimRight(providerConfig.Example(), "\r\n") + "\n",
+					Content: []*yaml.Node{
+						{
+							Kind:        yaml.ScalarNode,
+							Value:       "example-key",
+							LineComment: "This is an example, can be removed",
+						},
+						{
+							Kind:  yaml.ScalarNode,
+							Value: "example-value",
+						},
+					},
+				},
+				{
+					Kind:        yaml.ScalarNode,
+					HeadComment: "list of resources to fetch",
 					Value:       "resources",
 				},
 				{

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -107,30 +107,18 @@ func (p *Provider) GetProviderConfig(_ context.Context, req *cqproto.GetProvider
 
 		data := &yaml.Node{
 			Kind: yaml.MappingNode,
-			// HeadComment doesn't work here
 			Content: []*yaml.Node{
 				{
 					Kind:  yaml.ScalarNode,
 					Value: "configuration",
 				},
 				{
-					Kind:        yaml.MappingNode,
-					HeadComment: strings.TrimRight(providerConfig.Example(), "\r\n") + "\n",
-					Content: []*yaml.Node{
-						{
-							Kind:        yaml.ScalarNode,
-							Value:       "example-key",
-							LineComment: "This is an example, can be removed",
-						},
-						{
-							Kind:  yaml.ScalarNode,
-							Value: "example-value",
-						},
-					},
+					Kind: yaml.ScalarNode,
+					Tag:  "!!null",
 				},
 				{
 					Kind:        yaml.ScalarNode,
-					HeadComment: "list of resources to fetch",
+					HeadComment: strings.TrimRight(providerConfig.Example(), "\r\n") + "\n \nlist of resources to fetch",
 					Value:       "resources",
 				},
 				{

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -117,7 +117,8 @@ func (p *Provider) GetProviderConfig(_ context.Context, req *cqproto.GetProvider
 					Tag:  "!!null",
 				},
 				{
-					Kind:        yaml.ScalarNode,
+					Kind: yaml.ScalarNode,
+					// double newline will leave only the last block of comments
 					HeadComment: strings.TrimRight(providerConfig.Example(), "\r\n") + "\n \nlist of resources to fetch",
 					Value:       "resources",
 				},


### PR DESCRIPTION
~Contrary to what the comment says, it can't be removed from the code (not a way I could find) because then the comments aren't processed, so they are omitted.~

~Any string monkey operations should be done on cq-core side (as core needs a valid YAML, otherwise the comments will probably get dropped again) so that's why I avoided them.~

This is the best we can do with the `\n \n` thing, double newlines will abort a comment block and `!!null` yaml tags can't have them. Indentation is not right but it's close enough:

```yaml
providers:
    # provider configurations
    - name: aws
      configuration:
      # Optional, Repeated. Add an accounts block for every account you want to assume-role into and fetch data from.
      # accounts:
      #   - id: <UNIQUE ACCOUNT IDENTIFIER>
      # ... snipped ...   
      # max_retries: 10
      # The maximum back off delay between attempts. The backoff delays exponentially with a jitter based on the number of attempts. Defaults to 30 seconds.
      # max_backoff: 30
      #  
      # list of resources to fetch
      resources:
        - accessanalyzer.analyzers
        - acm.certificates
        - apigateway.api_keys
# ... and so on
```