### PR TITLE
fix: Use 'cur' ulimit in calculation, not 'max'

### DIFF
--- a/helpers/limit/limits.go
+++ b/helpers/limit/limits.go
@@ -25,13 +25,13 @@ type Rlimit struct {
 func GetMaxGoRoutines() uint64 {
 	limit := calculateGoRoutines(getMemory())
 	ulimit, err := GetUlimit()
-	if err != nil || ulimit.Max == 0 {
+	if err != nil || ulimit.Cur == 0 {
 		return limit
 	}
-	if ulimit.Max > limit {
+	if ulimit.Cur > limit {
 		return limit
 	}
-	return ulimit.Max
+	return ulimit.Cur
 }
 
 // DiagnoseLimits verifies if user should increase ulimit or max file descriptors to improve number of expected
@@ -48,11 +48,11 @@ func DiagnoseLimits() (diags diag.Diagnostics) {
 			diag.WithDetails("available descriptor capacity is %d want %d to run optimally, consider increasing max file descriptors on machine.", fds, want)))
 	}
 	ulimit, err := GetUlimit()
-	if err == nil && ulimit.Max < want {
+	if err == nil && ulimit.Cur < want {
 		diags = diags.Add(diag.NewBaseError(errors.New("ulimit available for CloudQuery process lower than expected"),
 			diag.USER,
 			diag.WithSeverity(diag.WARNING),
-			diag.WithDetails("set ulimit capacity is %d want %d to run optimally, consider increasing ulimit on this machine.", ulimit.Max, want)))
+			diag.WithDetails("set ulimit capacity is %d want %d to run optimally, consider increasing ulimit on this machine.", ulimit.Cur, want)))
 	}
 	return diags
 }


### PR DESCRIPTION
The 'cur' ulimit is the actual limit on num-open-files enforced by the kernel.

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
