### PR TITLE
feat(tests): Fetch only the resources required for test being run

### DIFF
--- a/provider/schema/table.go
+++ b/provider/schema/table.go
@@ -48,7 +48,7 @@ type Table struct {
 	AlwaysDelete bool
 
 	// IgnoreInTests is used to exclude a table from integration tests.
-	// By default, integration tests fetch all resources from cloudquery's test account, and verifY all tables
+	// By default, integration tests fetch all resources from cloudquery's test account, and verify all tables
 	// have at least one row.
 	// When IgnoreInTests is true, integration tests won't fetch from this table.
 	// Used when it is hard to create a reproducible environment with a row in this table.

--- a/provider/testing/resource.go
+++ b/provider/testing/resource.go
@@ -88,7 +88,7 @@ func TestResource(t *testing.T, resource ResourceTestCase) {
 	}
 
 	for resourceName, table := range resource.Provider.ResourceMap {
-		t.Run(table.Name, func(t *testing.T) {
+		t.Run(resourceName, func(t *testing.T) {
 			testErr := testResource(t, resource, resourceName, table, conn)
 			if testErr != nil {
 				t.Errorf("Error testing %v: %v", table.Name, testErr)

--- a/provider/testing/resource.go
+++ b/provider/testing/resource.go
@@ -10,11 +10,6 @@ import (
 	"testing"
 
 	sq "github.com/Masterminds/squirrel"
-	"github.com/cloudquery/faker/v3"
-	"github.com/georgysavva/scany/pgxscan"
-	"github.com/hashicorp/go-hclog"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/cloudquery/cq-provider-sdk/cqproto"
 	"github.com/cloudquery/cq-provider-sdk/database"
 	"github.com/cloudquery/cq-provider-sdk/migration"
@@ -23,6 +18,10 @@ import (
 	"github.com/cloudquery/cq-provider-sdk/provider/execution"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 	"github.com/cloudquery/cq-provider-sdk/testlog"
+	"github.com/cloudquery/faker/v3"
+	"github.com/georgysavva/scany/pgxscan"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
 )
 
 type ResourceTestCase struct {
@@ -121,7 +120,7 @@ func testResource(t *testing.T, resource ResourceTestCase, name string, table *s
 		// fallback to default verification
 		verifyNoEmptyColumns(t, table, conn, resource.SkipIgnoreInTest)
 	}
-	
+
 	return nil
 }
 

--- a/provider/testing/resource.go
+++ b/provider/testing/resource.go
@@ -10,6 +10,11 @@ import (
 	"testing"
 
 	sq "github.com/Masterminds/squirrel"
+	"github.com/cloudquery/faker/v3"
+	"github.com/georgysavva/scany/pgxscan"
+	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/cloudquery/cq-provider-sdk/cqproto"
 	"github.com/cloudquery/cq-provider-sdk/database"
 	"github.com/cloudquery/cq-provider-sdk/migration"
@@ -18,10 +23,6 @@ import (
 	"github.com/cloudquery/cq-provider-sdk/provider/execution"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 	"github.com/cloudquery/cq-provider-sdk/testlog"
-	"github.com/cloudquery/faker/v3"
-	"github.com/georgysavva/scany/pgxscan"
-	"github.com/hashicorp/go-hclog"
-	"github.com/stretchr/testify/assert"
 )
 
 type ResourceTestCase struct {
@@ -75,52 +76,60 @@ func TestResource(t *testing.T, resource ResourceTestCase) {
 	l.SetLevel(hclog.Info)
 	resource.Provider.Logger = l
 
-	for _, table := range resource.Provider.ResourceMap {
-		if err := dropAndCreateTable(context.Background(), conn, table); err != nil {
-			assert.FailNow(t, fmt.Sprintf("failed to create tables %s", table.Name), err)
-		}
-	}
-
-	if err = fetch(t, &resource); err != nil {
-		t.Fatal(err)
-	}
-
-	for resourceName, table := range resource.Provider.ResourceMap {
-		if verifiers, ok := resource.Verifiers[resourceName]; ok {
-			for _, verifier := range verifiers {
-				verifier(t, table, conn, resource.SkipIgnoreInTest)
-			}
-		} else {
-			// fallback to default verification
-			verifyNoEmptyColumns(t, table, conn, resource.SkipIgnoreInTest)
-		}
-	}
-}
-
-// fetch - fetches resources from the cloud and puts them into database. database config can be specified via DATABASE_URL env variable
-func fetch(t *testing.T, resource *ResourceTestCase) error {
-	t.Helper()
-	resourceNames := make([]string, 0, len(resource.Provider.ResourceMap))
-	for name, table := range resource.Provider.ResourceMap {
-		if !resource.SkipIgnoreInTest && table.IgnoreInTests {
-			t.Logf("skipping resource: %s in tests", name)
-			continue
-		}
-		resourceNames = append(resourceNames, name)
-	}
-
-	t.Logf("fetch resources %v", resourceNames)
-
-	if resp, err := resource.Provider.ConfigureProvider(context.Background(), &cqproto.ConfigureProviderRequest{
+	// configure provider
+	if resp, configErr := resource.Provider.ConfigureProvider(context.Background(), &cqproto.ConfigureProviderRequest{
 		CloudQueryVersion: "",
 		Connection: cqproto.ConnectionDetails{DSN: getEnv("DATABASE_URL",
 			"host=localhost user=postgres password=pass DB.name=postgres port=5432")},
 		Config: []byte(resource.Config),
-	}); err != nil {
-		return err
+	}); configErr != nil {
+		t.Fatal("failed to configure provider", configErr)
 	} else if resp != nil && resp.Diagnostics.HasErrors() {
-		return resp.Diagnostics
+		t.Fatal("errors while configuring provider", configErr)
 	}
+
+	for resourceName, table := range resource.Provider.ResourceMap {
+		t.Run(table.Name, func(t *testing.T) {
+			testErr := testResource(t, resource, resourceName, table, conn)
+			if testErr != nil {
+				t.Errorf("Error testing %v: %v", table.Name, testErr)
+			}
+		})
+	}
+}
+
+func testResource(t *testing.T, resource ResourceTestCase, name string, table *schema.Table, conn execution.QueryExecer) error {
+	t.Helper()
+
+	if createErr := dropAndCreateTable(context.Background(), conn, table); createErr != nil {
+		assert.FailNow(t, fmt.Sprintf("failed to create table %s", table.Name), createErr)
+	}
+
+	if !resource.SkipIgnoreInTest && table.IgnoreInTests {
+		t.Logf("skipping fetch of resource: %s in tests", name)
+	} else {
+		if err := fetchResource(t, &resource, name); err != nil {
+			return err
+		}
+	}
+
+	if verifiers, ok := resource.Verifiers[name]; ok {
+		for _, verifier := range verifiers {
+			verifier(t, table, conn, resource.SkipIgnoreInTest)
+		}
+	} else {
+		// fallback to default verification
+		verifyNoEmptyColumns(t, table, conn, resource.SkipIgnoreInTest)
+	}
+	
+	return nil
+}
+
+// fetchResource - fetches a resource from the cloud and puts them into database. database config can be specified via DATABASE_URL env variable
+func fetchResource(t *testing.T, resource *ResourceTestCase, resourceName string) error {
+	t.Helper()
+
+	t.Logf("fetch resource %v", resourceName)
 
 	var resourceSender = &testResourceSender{
 		Errors: []string{},
@@ -128,7 +137,7 @@ func fetch(t *testing.T, resource *ResourceTestCase) error {
 
 	if err := resource.Provider.FetchResources(context.Background(),
 		&cqproto.FetchResourcesRequest{
-			Resources:             resourceNames,
+			Resources:             []string{resourceName},
 			ParallelFetchingLimit: resource.ParallelFetchingLimit,
 		},
 		resourceSender,
@@ -137,7 +146,7 @@ func fetch(t *testing.T, resource *ResourceTestCase) error {
 	}
 
 	if len(resourceSender.Errors) > 0 {
-		return fmt.Errorf("error/s occur during test, %s", strings.Join(resourceSender.Errors, ", "))
+		return fmt.Errorf("error/s occurred during test, %s", strings.Join(resourceSender.Errors, ", "))
 	}
 
 	return nil


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

This closes https://github.com/cloudquery/cq-provider-sdk/issues/398

When adding a new resource, it is desirable to only fetch that resource during integration testing. Before this change, all resources were fetched (which took about 3.5 minutes). After the change, only the resources required by the subtest are fetched (so test runs for cq-provider-aws now take about 10 seconds on my machine, when limiting to a specific table). 

For example, when running integration tests with:

```
go test -v -run="TestIntegration/aws_lightsail_instances" -tags=integration ./...
```

only the resources required to populate the `aws_lightsail_instances` and related tables will be fetched. If a subtest is not being run, all resources will still be fetched. This means integration tests for a specific resource can be run in about 10 seconds, as opposed to the several minutes it took before. The trade-off is, however, that the full suite will take slightly longer to run. I think this is worthwhile trade-off to make, as long as we're not also jeopardizing correctness. I think this could happen if there are dependencies between resources, but hopefully the tests for this PR will fail now if this is the case.

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [x] Ensure the status checks below are successful ✅
