### PR TITLE
fix: Remove dead code

### DIFF
--- a/provider/execution/errors.go
+++ b/provider/execution/errors.go
@@ -14,20 +14,6 @@ const (
 
 type ErrorClassifier func(meta schema.ClientMeta, resourceName string, err error) diag.Diagnostics
 
-func defaultErrorClassifier(_ schema.ClientMeta, resourceName string, err error) diag.Diagnostics {
-	if _, ok := err.(diag.Diagnostic); ok {
-		return nil
-	}
-	if _, ok := err.(diag.Diagnostics); ok {
-		return nil
-	}
-	if strings.Contains(err.Error(), ": socket: too many open files") {
-		// Return a Diagnostic error so that it can be properly propagated back to the user via the CLI
-		return fromError(err, diag.WithResourceName(resourceName), diag.WithSummary(fdLimitMessage), diag.WithType(diag.THROTTLE), diag.WithSeverity(diag.WARNING))
-	}
-	return nil
-}
-
 func ClassifyError(err error, opts ...diag.BaseErrorOption) diag.Diagnostics {
 	if err != nil && strings.Contains(err.Error(), ": socket: too many open files") {
 		// Return a Diagnostic error so that it can be properly propagated back to the user via the CLI

--- a/provider/execution/execution_test.go
+++ b/provider/execution/execution_test.go
@@ -600,9 +600,6 @@ func TestTableExecutor_Resolve(t *testing.T) {
 			if tc.SetupStorage != nil {
 				storage = tc.SetupStorage(t)
 			}
-			if tc.Name == "ignore_error_recursive" {
-				fmt.Println("debug")
-			}
 			limiter := semaphore.NewWeighted(int64(limit.GetMaxGoRoutines()))
 			exec := NewTableExecutor(tc.Name, storage, testlog.New(t), tc.Table, nil, nil, limiter, 10*time.Second)
 			count, diags := exec.Resolve(context.Background(), executionClient)


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

The code inside the defaultErrorClassifier was never actually executed, because it was always passed a 'diag', but the first line in defaultErrorClassifier was "if err type is diag, return nil".

In any case, it's definitely better not to classify a single error twice. A more reasonable implementation might be to 'fall back to default classifier, if specific classifier returned nil', but for now, let's just remove it.

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
