### PR TITLE
feat: Add ToPointer helper function to convert values to pointers

### DIFF
--- a/helpers/pointers.go
+++ b/helpers/pointers.go
@@ -1,0 +1,20 @@
+package helpers
+
+import "reflect"
+
+// ToPointer takes an interface{} object and will return a pointer to this object
+// if the object is not already a pointer. Otherwise, it will return the original value.
+// It is safe to typecast the return-value of GetPointer into a pointer of the right type,
+// except in very special cases (such as passing in nil without an explicit type)
+func ToPointer(v interface{}) interface{} {
+	val := reflect.ValueOf(v)
+	if val.Kind() == reflect.Ptr {
+		return v
+	}
+	if !val.IsValid() {
+		return v
+	}
+	p := reflect.New(val.Type())
+	p.Elem().Set(val)
+	return p.Interface()
+}

--- a/helpers/pointers_test.go
+++ b/helpers/pointers_test.go
@@ -1,0 +1,50 @@
+package helpers
+
+import (
+	"testing"
+)
+
+type testStruct struct {
+	test string
+}
+
+func TestToPointer(t *testing.T) {
+	// passing string should return pointer to string
+	give := "test"
+	got := ToPointer(give)
+	if _, ok := got.(*string); !ok {
+		t.Errorf("ToPointer(%q) returned %q, expected type *string", give, got)
+	}
+
+	// passing struct by value should return pointer to (copy of the) struct
+	giveObj := testStruct{
+		test: "value",
+	}
+	gotStruct := ToPointer(giveObj)
+	if _, ok := gotStruct.(*testStruct); !ok {
+		t.Errorf("ToPointer(%q) returned %q, expected type *testStruct", giveObj, gotStruct)
+	}
+
+	// passing pointer should return the original pointer
+	ptr := &giveObj
+	gotPointer := ToPointer(ptr)
+	if gotPointer != ptr {
+		t.Errorf("ToPointer(%q) returned %q, expected %q", ptr, gotPointer, ptr)
+	}
+
+	// passing nil should return nil back without panicking
+	gotNil := ToPointer(nil)
+	if gotNil != nil {
+		t.Errorf("ToPointer(%v) returned %q, expected nil", nil, gotNil)
+	}
+
+	// passing number should return pointer to number
+	giveNumber := int64(0)
+	gotNumber := ToPointer(giveNumber)
+	if v, ok := gotNumber.(*int64); !ok {
+		t.Errorf("ToPointer(%q) returned %q, expected type *int64", giveNumber, gotNumber)
+		if *v != 0 {
+			t.Errorf("ToPointer(%q) returned %q, expected 0", giveNumber, gotNumber)
+		}
+	}
+}


### PR DESCRIPTION
This adds a new helper function that will be useful in automatically generated resolver functions, where we can't always be sure whether the passed in type will be a pointer or a value. With this helper, we can force it to always be a pointer and perform a safe typecast afterwards.

Example usage:

```
func fetchBasePointerRelationInnerRelations(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
	r := helpers.ToPointer(parent.Item).(*tests.PointerRelationStruct)
        // rest of function...
}
```

Alternatively, if we didn't have this function, we could do:

```
func fetchBasePointerRelationInnerRelations(ctx context.Context, meta schema.ClientMeta, parent *schema.Resource, res chan<- interface{}) error {
	var r *tests.PointerRelationStruct
	switch v := parent.Item.(type) {
	case tests.PointerRelationStruct:
		r = &v
	case *tests.PointerRelationStruct:
		r = v
	}
        // rest of function...
```

IMO it's nice to have this helper so that the resolvers can remain minimal.