### PR TITLE
fix: Add support for int32 and int64 array types

### DIFF
--- a/provider/schema/column.go
+++ b/provider/schema/column.go
@@ -232,7 +232,7 @@ func (c Column) checkType(v interface{}) bool {
 		return c.Type == TypeFloat
 	case []string, []*string, *[]string:
 		return c.Type == TypeStringArray || c.Type == TypeJSON
-	case []int, []*int, *[]int:
+	case []int, []*int, *[]int, []int32, []*int32, []int64, []*int64, *[]int64:
 		return c.Type == TypeIntArray || c.Type == TypeJSON
 	case []interface{}:
 		return c.Type == TypeJSON


### PR DESCRIPTION
#### Summary

Attributes that are of type []int32 or []int64 should also be converted to int arrays in Postgres. Currently this is not supported.
