### PR TITLE
fix: Fixed print of diag errors

### DIFF
--- a/provider/testing/resource.go
+++ b/provider/testing/resource.go
@@ -84,7 +84,7 @@ func TestResource(t *testing.T, resource ResourceTestCase) {
 	}); configErr != nil {
 		t.Fatal("failed to configure provider", configErr)
 	} else if resp != nil && resp.Diagnostics.HasErrors() {
-		t.Fatal("errors while configuring provider", configErr)
+		t.Fatal("errors while configuring provider", resp.Diagnostics.Error())
 	}
 
 	for resourceName, table := range resource.Provider.ResourceMap {


### PR DESCRIPTION
<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

fixed print of provider configuration error when error is in diags.

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
