### PR TITLE
fix: Bug where non-utc timestamps were stripped of their timezone in …

### DIFF
--- a/provider/schema/dialect.go
+++ b/provider/schema/dialect.go
@@ -257,6 +257,8 @@ func doResourceValues(dialect Dialect, r *Resource) ([]interface{}, error) {
 			default:
 				values = append(values, data)
 			}
+		case TypeTimestamp:
+			values = append(values, maybeChangeTimestampToUtc(v))
 		default:
 			values = append(values, v)
 		}

--- a/provider/schema/resource.go
+++ b/provider/schema/resource.go
@@ -94,9 +94,27 @@ func (r *Resource) Values() ([]interface{}, error) {
 		if err := c.ValidateType(v); err != nil {
 			return nil, err
 		}
+
+		// If the column is a timestamp, change it to UTC before inserting
+		v = maybeChangeTimestampToUtc(v)
+
 		values = append(values, v)
 	}
 	return values, nil
+}
+
+func maybeChangeTimestampToUtc(value interface{}) interface{} {
+	switch concrete := value.(type) {
+	case time.Time:
+		return concrete.UTC()
+	case *time.Time:
+		if concrete != nil {
+			return concrete.UTC()
+		}
+		return value
+	default:
+		return value
+	}
 }
 
 func (r *Resource) GenerateCQId() error {


### PR DESCRIPTION
…the database

<!-- 🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉 -->

#### Summary

<!--
Explain what problem this PR addresses
-->

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Test locally on your own infrastructure
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation)) 
- [ ] Update or add tests 🧪
- [ ] Ensure the status checks below are successful ✅
